### PR TITLE
fix: Publish pipeline

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Publish
         uses: menduz/oddish-action@master
         with:
-          cwd: './build'
+          cwd: './dist'
           deterministic-snapshot: true
           registry-url: 'https://registry.npmjs.org'
           access: public


### PR DESCRIPTION
This PR fixes the publish pipeline by changing the directory oddish is ran in.