### PR TITLE
feat: Get avatar name

### DIFF
--- a/src/modules/profile/utils.spec.ts
+++ b/src/modules/profile/utils.spec.ts
@@ -1,0 +1,63 @@
+import { Avatar } from '@dcl/schemas'
+import { getAvatarName } from './utils'
+
+let avatar: Avatar | undefined
+
+describe("when getting an avatar's name", () => {
+  describe('and the avatar is undefined', () => {
+    beforeEach(() => {
+      avatar = undefined
+    })
+
+    it('should return default name without last part', () => {
+      expect(getAvatarName(avatar)).toEqual({ name: 'Unnamed' })
+    })
+  })
+
+  describe('and the avatar is defined', () => {
+    beforeEach(() => {
+      avatar = {
+        userId: '0xc0ffee254729296a45a3885639AC7E10F9d54979',
+        name: 'aName'
+      } as Avatar
+    })
+
+    describe('and the name is claimed', () => {
+      beforeEach(() => {
+        avatar = { ...avatar, hasClaimedName: true } as Avatar
+      })
+
+      it("should return the avatar's name without last part", () => {
+        expect(getAvatarName(avatar)).toEqual({ name: avatar?.name })
+      })
+    })
+
+    describe('and the name was not claimed', () => {
+      let lastPart: string
+
+      beforeEach(() => {
+        avatar = { ...avatar, hasClaimedName: false } as Avatar
+        lastPart = `#${avatar?.userId.slice(-4)}`
+      })
+
+      describe('and the name has a last part', () => {
+        let avatarName: string
+
+        beforeEach(() => {
+          avatarName = avatar?.name ?? ''
+          avatar = { ...avatar, name: avatarName + lastPart } as Avatar
+        })
+
+        it("should return the avatar's name and the last part", () => {
+          expect(getAvatarName(avatar)).toEqual({ name: avatarName, lastPart })
+        })
+      })
+
+      describe('and the name does not have a last part', () => {
+        it("should return the avatar's name with the last part", () => {
+          expect(getAvatarName(avatar)).toEqual({ name: avatar?.name, lastPart })
+        })
+      })
+    })
+  })
+})

--- a/src/modules/profile/utils.ts
+++ b/src/modules/profile/utils.ts
@@ -1,0 +1,16 @@
+import { Avatar } from '@dcl/schemas'
+
+export const getAvatarName = (avatar?: Avatar): { name: string; lastPart?: string } => {
+  if (!avatar) {
+    return { name: 'Unnamed' }
+  }
+
+  if (avatar.hasClaimedName) {
+    return { name: avatar.name }
+  }
+
+  const lastPart = `#${avatar?.userId.slice(-4)}`
+  const name = avatar.name.endsWith(lastPart) ? avatar.name.substring(0, avatar.name.length - lastPart.length) : avatar.name
+
+  return { name: name, lastPart: lastPart }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
This PR adds the `getAvatarName` function that returns the name and the "last part" of it if the avatar has an unclaimed name.