### PR TITLE
fix: Load others worlds

### DIFF
--- a/src/components/ProfileInformation/ProfileInformation.tsx
+++ b/src/components/ProfileInformation/ProfileInformation.tsx
@@ -69,7 +69,7 @@ const ProfileInformation = (props: Props) => {
       </div>
       <div className={styles.actions}>
         {shouldShowFriendsButton ? <FriendshipButton friendAddress={profileAddress} /> : null}
-        {loggedInAddress ? <WorldsButton address={loggedInAddress} /> : null}
+        {loggedInAddress ? <WorldsButton isLoggedIn={isLoggedInProfile} address={profileAddress} /> : null}
         <Dropdown
           className={styles.smallButton}
           icon={

--- a/src/components/WorldsButton/WorldsButton.tsx
+++ b/src/components/WorldsButton/WorldsButton.tsx
@@ -43,8 +43,6 @@ const WorldsButton = (props: Props) => {
     onFetchWorlds(address)
   }, [address])
 
-  console.log({ hasWorlds, isLoading, hasNames, isLoggedIn })
-
   return (
     <>
       <Dropdown

--- a/src/components/WorldsButton/WorldsButton.tsx
+++ b/src/components/WorldsButton/WorldsButton.tsx
@@ -18,7 +18,7 @@ const WORLDS_CONTENT_SERVER_URL = config.get('WORLDS_CONTENT_SERVER_URL')
 const isDevelopment = config.getEnv() === Env.DEVELOPMENT
 
 const WorldsButton = (props: Props) => {
-  const { address, isLoading, className, hasNames, worlds, onFetchWorlds } = props
+  const { address, isLoading, isLoggedIn, className, hasNames, worlds, onFetchWorlds } = props
 
   const hasWorlds = worlds.length > 0
 
@@ -43,10 +43,13 @@ const WorldsButton = (props: Props) => {
     onFetchWorlds(address)
   }, [address])
 
+  console.log({ hasWorlds, isLoading, hasNames, isLoggedIn })
+
   return (
     <>
       <Dropdown
         className={classNames(className, styles.worldDropdown)}
+        disabled={!isLoading && !hasWorlds && !isLoggedIn}
         direction="left"
         open={!hasNames || (hasNames && !hasWorlds) ? false : undefined}
         trigger={
@@ -59,19 +62,19 @@ const WorldsButton = (props: Props) => {
               className,
               styles.worldButton,
               'customIconButton',
-              { [styles.smallButton]: isLoading || (hasWorlds && hasNames) },
+              { [styles.smallButton]: isLoading || hasWorlds || !isLoggedIn },
               styles.actionButton
             )}
           >
-            {!hasNames && !isLoading ? (
+            {!hasNames && !isLoading && isLoggedIn ? (
               <>
                 <img src={verifiedIcon} /> {t('worlds_button.get_a_name')}
               </>
-            ) : hasNames && !hasWorlds && !isLoading ? (
+            ) : hasNames && !hasWorlds && !isLoading && isLoggedIn ? (
               <>
                 <img src={worldIcon} /> {t('worlds_button.activate_world')}
               </>
-            ) : hasWorlds && !isLoading ? (
+            ) : !isLoading && (hasWorlds || !isLoggedIn) ? (
               <img src={worldIcon} />
             ) : null}
           </Button>

--- a/src/components/WorldsButton/WorldsButton.types.ts
+++ b/src/components/WorldsButton/WorldsButton.types.ts
@@ -8,6 +8,7 @@ export type Props = {
   worlds: World[]
   isLoading: boolean
   hasNames: boolean
+  isLoggedIn?: boolean
   onFetchWorlds: (address: string) => void
 }
 


### PR DESCRIPTION
This PR changes the WorldsButton to recognize if it's loading the worlds of the logged in user or the one being viewed to decide wether to recommend them to create a world or claim a name or not.