### PR TITLE
fix: Lowercase addresses when logging in

### DIFF
--- a/src/modules/identity/sagas.ts
+++ b/src/modules/identity/sagas.ts
@@ -23,7 +23,7 @@ import { generateIdentity } from './utils'
 export function* identitySaga() {
   yield takeEvery(loginRequest.type, handleLogin)
   yield takeEvery(CHANGE_ACCOUNT, handleChangeAccount)
-  yield takeEvery(CONNECT_WALLET_SUCCESS, handleConnectWalletSuccessAndChangeAccount)
+  yield takeEvery(CONNECT_WALLET_SUCCESS, handleConnectWalletSuccess)
   yield takeEvery(DISCONNECT_WALLET, handleDisconnectWallet)
 
   function* handleLogin(action: LoginRequestAction) {
@@ -81,23 +81,24 @@ export function* identitySaga() {
     yield location.reload()
   }
 
-  function* handleConnectWalletSuccessAndChangeAccount(action: ConnectWalletSuccessAction | ChangeAccountAction) {
+  function* handleConnectWalletSuccess(action: ConnectWalletSuccessAction | ChangeAccountAction) {
     const { wallet } = action.payload
     const { address } = wallet
+    const lowerCasedAddress = address.toLowerCase()
 
-    auxAddress = address
+    auxAddress = lowerCasedAddress
 
     let identity: AuthIdentity
 
-    const ssoIdentity: AuthIdentity | null = yield call(getIdentity, address)
+    const ssoIdentity: AuthIdentity | null = yield call(getIdentity, lowerCasedAddress)
 
     if (!ssoIdentity) {
-      identity = yield call(generateIdentity, address)
-      yield call(storeIdentity, address, identity)
+      identity = yield call(generateIdentity, lowerCasedAddress)
+      yield call(storeIdentity, lowerCasedAddress, identity)
     } else {
       identity = ssoIdentity
     }
 
-    yield put(loginSuccess({ address: wallet.address, identity }))
+    yield put(loginSuccess({ address: lowerCasedAddress, identity }))
   }
 }

--- a/src/modules/social/client.ts
+++ b/src/modules/social/client.ts
@@ -10,7 +10,7 @@ const SOCIAL_RPC_URL = config.get('SOCIAL_RPC_URL')
 let socialClient: SocialClient | undefined
 
 export const initiateSocialClient = async (address: string, identity: AuthIdentity): Promise<SocialClient> => {
-  socialClient = await createSocialClient(SYNAPSE_URL, SOCIAL_RPC_URL, address, identity)
+  socialClient = await createSocialClient(SYNAPSE_URL, SOCIAL_RPC_URL, address.toLowerCase(), identity)
   return socialClient
 }
 

--- a/src/modules/social/sagas.spec.ts
+++ b/src/modules/social/sagas.spec.ts
@@ -69,14 +69,14 @@ describe('when handling the fetch friends requests action', () => {
     beforeEach(() => {
       incomingEvents = [
         {
-          address: '0x1',
+          address: '0x1b',
           createdAt: 123456789,
           message: undefined
         }
       ]
       outgoingEvents = [
         {
-          address: '0x2',
+          address: '0x2b',
           createdAt: 123456789,
           message: undefined
         }
@@ -92,11 +92,11 @@ describe('when handling the fetch friends requests action', () => {
               getRequestEvents: () =>
                 Promise.resolve({
                   incoming: {
-                    items: [{ user: { address: incomingEvents[0].address }, createdAt: incomingEvents[0].createdAt }],
+                    items: [{ user: { address: incomingEvents[0].address.toUpperCase() }, createdAt: incomingEvents[0].createdAt }],
                     total: incomingEvents.length
                   },
                   outgoing: {
-                    items: [{ user: { address: outgoingEvents[0].address }, createdAt: outgoingEvents[0].createdAt }],
+                    items: [{ user: { address: outgoingEvents[0].address.toUpperCase() }, createdAt: outgoingEvents[0].createdAt }],
                     total: outgoingEvents.length
                   }
                 })
@@ -147,7 +147,7 @@ describe('when handing the login success action', () => {
         .put(initializeSocialClientRequest())
         .call.like({
           fn: initiateSocialClient,
-          args: [address, identity]
+          args: [address.toLocaleLowerCase(), identity]
         })
         .put(initializeSocialClientSuccess())
         .dispatch(loginSuccess({ address, identity }))

--- a/src/modules/social/sagas.ts
+++ b/src/modules/social/sagas.ts
@@ -83,13 +83,13 @@ export function* socialSagas() {
       const requestEvents: Awaited<ReturnType<SocialClient['getRequestEvents']>> = yield call([client, 'getRequestEvents'])
       const incoming: RequestEvent[] =
         requestEvents?.incoming?.items.map(event => ({
-          address: event.user?.address ?? 'Unknown',
+          address: event.user?.address.toLowerCase() ?? 'Unknown',
           createdAt: event.createdAt,
           message: event.message
         })) ?? []
       const outgoing: RequestEvent[] =
         requestEvents?.outgoing?.items.map(event => ({
-          address: event.user?.address ?? 'Unknown',
+          address: event.user?.address.toLowerCase() ?? 'Unknown',
           createdAt: event.createdAt,
           message: event.message
         })) ?? []


### PR DESCRIPTION
This PR does the following:
- Lowercases the address when logging in and signing the identity.
- Lowercases the addresses when receiving the friendship requests.