### PR TITLE
fix: Don't show mutual friends when logging out

### DIFF
--- a/src/components/FriendsCounter/FriendsCounter.spec.tsx
+++ b/src/components/FriendsCounter/FriendsCounter.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '../../tests/tests'
+import { FRIENDS_COUNTER_DATA_TEST_ID } from './constants'
 import FriendsCounter from './FriendsCounter'
 import { Props } from './FriendsCounter.types'
 
@@ -16,7 +17,7 @@ describe('when rendering the FriendsCounter with the friends count in zero', () 
   })
 
   it('should render the component with the friends count without the clickable class', async () => {
-    const button = await renderedComponent.getByTestId('FriendsCounter')
+    const button = renderedComponent.getByTestId(FRIENDS_COUNTER_DATA_TEST_ID)
     expect(button).not.toHaveClass('clickable')
     expect(button).toHaveTextContent('0 friends')
   })
@@ -28,7 +29,7 @@ describe('when rendering the FriendsCounter with the friends count greater than 
   })
 
   it('should render the component with the friends count without the clickable class', () => {
-    const button = renderedComponent.getByTestId('FriendsCounter')
+    const button = renderedComponent.getByTestId(FRIENDS_COUNTER_DATA_TEST_ID)
     expect(button).toHaveClass('clickable')
     expect(button).toHaveTextContent('3 friends')
   })
@@ -40,7 +41,7 @@ describe('when rendering the FriendsCounter in its loading state', () => {
   })
 
   it('should render the component with a loader', () => {
-    expect(renderedComponent.getByTestId('FriendsCounter').querySelector('.loader')).not.toBeNull()
+    expect(renderedComponent.getByTestId(FRIENDS_COUNTER_DATA_TEST_ID).querySelector('.loader')).not.toBeNull()
   })
 })
 
@@ -50,7 +51,7 @@ describe('when clicking the FriendsCounter with a zero count', () => {
   beforeEach(() => {
     onClick = jest.fn()
     renderedComponent = renderFriendsCounter({ count: 0, onClick })
-    const button = renderedComponent.getByTestId('FriendsCounter')
+    const button = renderedComponent.getByTestId(FRIENDS_COUNTER_DATA_TEST_ID)
     fireEvent.click(button)
   })
 
@@ -65,7 +66,7 @@ describe('when clicking the FriendsCounter with a greater than zero count', () =
   beforeEach(() => {
     onClick = jest.fn()
     renderedComponent = renderFriendsCounter({ count: 3, onClick })
-    const button = renderedComponent.getByTestId('FriendsCounter')
+    const button = renderedComponent.getByTestId(FRIENDS_COUNTER_DATA_TEST_ID)
     fireEvent.click(button)
   })
 

--- a/src/components/FriendsCounter/FriendsCounter.tsx
+++ b/src/components/FriendsCounter/FriendsCounter.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Loader } from 'decentraland-ui/dist/components/Loader/Loader'
 import userIcon from '../../assets/icons/User.png'
+import { FRIENDS_COUNTER_DATA_TEST_ID } from './constants'
 import { Props } from './FriendsCounter.types'
 import styles from './FriendsCounter.module.css'
 
@@ -14,7 +15,7 @@ const FriendsCounter = (props: Props) => {
       className={classNames(styles.counter, className, { [styles.clickable]: count > 0 })}
       role="button"
       onClick={count > 0 ? onClick : undefined}
-      data-testid="FriendsCounter"
+      data-testid={FRIENDS_COUNTER_DATA_TEST_ID}
     >
       {isLoading ? (
         <Loader active inline size="mini" />

--- a/src/components/FriendsCounter/constants.ts
+++ b/src/components/FriendsCounter/constants.ts
@@ -1,0 +1,1 @@
+export const FRIENDS_COUNTER_DATA_TEST_ID = 'FriendsCounter'

--- a/src/components/FriendsCounter/index.ts
+++ b/src/components/FriendsCounter/index.ts
@@ -1,4 +1,5 @@
 import FriendsCounter from './FriendsCounter.container'
 export * from './FriendsCounter.types'
+export * from './constants'
 
 export default FriendsCounter

--- a/src/components/MutualFriendsCounter/MutualFriendsCounter.spec.tsx
+++ b/src/components/MutualFriendsCounter/MutualFriendsCounter.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '../../tests/tests'
+import { MUTUALS_COUNTER_DATA_TEST_ID } from './constants'
 import MutualFriendsCounter from './MutualFriendsCounter'
 import { Props } from './MutualFriendsCounter.types'
 
@@ -26,7 +27,7 @@ describe('when rendering the component with the friends count in zero', () => {
   })
 
   it('should not render the component', () => {
-    expect(renderedComponent.queryByTestId('mutual-friends-counter')).toBeNull()
+    expect(renderedComponent.queryByTestId(MUTUALS_COUNTER_DATA_TEST_ID)).toBeNull()
   })
 })
 
@@ -36,7 +37,7 @@ describe('when rendering the component with the friends count greater than zero'
   })
 
   it('should render the component with the friends count without the clickable class', () => {
-    const button = renderedComponent.getByTestId('mutual-friends-counter')
+    const button = renderedComponent.getByTestId(MUTUALS_COUNTER_DATA_TEST_ID)
     expect(button).toHaveClass('clickable')
     expect(button).toHaveTextContent('3 mutual')
   })
@@ -48,7 +49,7 @@ describe('when clicking the component with a greater than zero count', () => {
   beforeEach(() => {
     onClick = jest.fn()
     renderedComponent = renderMutualFriendsCounter({ count: 3, onClick })
-    const button = renderedComponent.getByTestId('mutual-friends-counter')
+    const button = renderedComponent.getByTestId(MUTUALS_COUNTER_DATA_TEST_ID)
     fireEvent.click(button)
   })
 
@@ -76,7 +77,7 @@ describe('when rendering the component in its loading state', () => {
   })
 
   it('should render the component with a loader', () => {
-    expect(renderedComponent.getByTestId('mutual-friends-counter').querySelector('.loader')).not.toBeNull()
+    expect(renderedComponent.getByTestId(MUTUALS_COUNTER_DATA_TEST_ID).querySelector('.loader')).not.toBeNull()
   })
 })
 

--- a/src/components/MutualFriendsCounter/MutualFriendsCounter.tsx
+++ b/src/components/MutualFriendsCounter/MutualFriendsCounter.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import Profile from 'decentraland-dapps/dist/containers/Profile'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Loader } from 'decentraland-ui/dist/components/Loader/Loader'
+import { MUTUALS_COUNTER_DATA_TEST_ID } from './constants'
 import { Props } from './MutualFriendsCounter.types'
 import styles from './MutualFriendsCounter.module.css'
 
@@ -22,7 +23,7 @@ const MutualFriendsCounter = (props: Props) => {
       className={classNames(styles.counter, className, { [styles.clickable]: count > 0 })}
       role="button"
       onClick={count > 0 ? onClick : undefined}
-      data-testid="mutual-friends-counter"
+      data-testid={MUTUALS_COUNTER_DATA_TEST_ID}
     >
       {isLoading ? (
         <Loader active inline size="mini" />

--- a/src/components/MutualFriendsCounter/constants.ts
+++ b/src/components/MutualFriendsCounter/constants.ts
@@ -1,0 +1,1 @@
+export const MUTUALS_COUNTER_DATA_TEST_ID = 'mutual-friends-counter'

--- a/src/components/ProfileInformation/ProfileInformation.tsx
+++ b/src/components/ProfileInformation/ProfileInformation.tsx
@@ -206,7 +206,7 @@ const ProfileInformation = (props: Props) => {
           {!isTabletAndBelow && renderActions()}
         </div>
         <div className={styles.friendsContainer}>
-          {isSocialClientReady && (
+          {isSocialClientReady && Boolean(loggedInAddress) && (
             <div className={styles.basicCenteredRow}>
               {isLoggedInProfile ? <FriendsCounter /> : <MutualFriendsCounter friendAddress={profileAddress} />}
             </div>


### PR DESCRIPTION
This PR adds a check to verify that the user is logged in before showing either the `FriendsCounter` or the `MutualFriendsCounter` component. This issue occurred when the user logged out from the site while viewing their own profile.
The PR also refactors a bit the tests of the `ProfileInformation` component.