### PR TITLE
feat: Make the friendship button available when the user is not logged in

### DIFF
--- a/src/components/FriendshipButton/FriendshipButton.container.ts
+++ b/src/components/FriendshipButton/FriendshipButton.container.ts
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux'
-// import { openModal } from 'decentraland-dapps/dist/modules/modal/actions'
 import { getProfileOfAddress } from 'decentraland-dapps/dist/modules/profile/selectors'
 import { RootState } from '../../modules/reducer'
 import {
   removeFriendRequest,
   acceptFriendshipRequest,
   requestFriendshipRequest,
-  cancelFriendshipRequestRequest
+  cancelFriendshipRequestRequest,
+  logInAndRequestFriendshipRequest
 } from '../../modules/social/actions'
 import {
   getFriendshipStatus,
@@ -39,7 +39,13 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
 const mapDispatch = (dispatch: MapDispatch, ownProps: OwnProps): MapDispatchProps => ({
   onCancelFriendRequest: () => dispatch(cancelFriendshipRequestRequest(ownProps.friendAddress)),
   onRemoveFriend: () => dispatch(removeFriendRequest(ownProps.friendAddress)),
-  onAddFriend: () => dispatch(requestFriendshipRequest(ownProps.friendAddress)),
+  onAddFriend: () => {
+    if (ownProps.isLoggedIn) {
+      dispatch(requestFriendshipRequest(ownProps.friendAddress))
+    } else {
+      dispatch(logInAndRequestFriendshipRequest(ownProps.friendAddress))
+    }
+  },
   onAcceptFriendRequest: () => dispatch(acceptFriendshipRequest(ownProps.friendAddress))
 })
 

--- a/src/components/FriendshipButton/FriendshipButton.types.ts
+++ b/src/components/FriendshipButton/FriendshipButton.types.ts
@@ -1,5 +1,4 @@
 import { Dispatch } from '@reduxjs/toolkit'
-// import { OpenModalAction, openModal } from 'decentraland-dapps/dist/modules/modal/actions'
 import { Profile } from 'decentraland-dapps/dist/modules/profile/types'
 import {
   CancelFriendshipRequestRequestAction,
@@ -7,7 +6,8 @@ import {
   RequestFriendshipRequestAction,
   AcceptFriendshipRequestAction,
   FetchFriendRequestsEventsRequestAction,
-  FetchFriendsRequestAction
+  FetchFriendsRequestAction,
+  LogInAndRequestFriendshipRequestAction
 } from '../../modules/social/actions'
 import { FriendshipStatus } from '../../modules/social/types'
 
@@ -21,9 +21,10 @@ export type Props = {
   friendshipStatus?: FriendshipStatus
   className?: string
   profile?: Profile
+  isLoggedIn?: boolean
 }
 
-export type OwnProps = Pick<Props, 'friendAddress' | 'className'>
+export type OwnProps = Pick<Props, 'friendAddress' | 'className' | 'isLoggedIn'>
 export type MapStateProps = Pick<Props, 'isLoading' | 'friendshipStatus' | 'profile'>
 export type MapDispatchProps = Pick<Props, 'onRemoveFriend' | 'onAcceptFriendRequest' | 'onCancelFriendRequest' | 'onAddFriend'>
 export type MapDispatch = Dispatch<
@@ -35,4 +36,5 @@ export type MapDispatch = Dispatch<
   | RequestFriendshipRequestAction
   | RemoveFriendRequestAction
   | AcceptFriendshipRequestAction
+  | LogInAndRequestFriendshipRequestAction
 >

--- a/src/components/HOC/WithProfile/WithProfile.container.ts
+++ b/src/components/HOC/WithProfile/WithProfile.container.ts
@@ -33,7 +33,7 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps): MapStateProps =>
 }
 
 const mapDispatch = (dispatch: MapDispatch, ownProps: OwnProps) => ({
-  onFetchProfile: () => dispatch(enhancedFetchProfileRequest(ownProps.router.params.profileAddress as string))
+  onFetchProfile: () => dispatch(enhancedFetchProfileRequest(ownProps.router.params.profileAddress?.toLowerCase() as string))
 })
 
 export default WithRouter(connect(mapStateToProps, mapDispatch)(WithProfile))

--- a/src/components/ProfileInformation/ProfileInformation.tsx
+++ b/src/components/ProfileInformation/ProfileInformation.tsx
@@ -37,7 +37,6 @@ const PROFILE_URL = config.get('PROFILE_URL', '')
 
 const ProfileInformation = (props: Props) => {
   const { profile, isSocialClientReady, loggedInAddress, profileAddress, isBlockedByLoggedUser, hasBlockedLoggedUser, onViewMore } = props
-  console.log({ loggedInAddress, profileAddress, profile })
 
   const [hasCopiedLink, setHasCopiedLink] = useTimer(1200)
   const [hasCopiedWallet, setHasCopiedWallet] = useTimer(1200)

--- a/src/components/ProfileInformation/ProfileInformation.tsx
+++ b/src/components/ProfileInformation/ProfileInformation.tsx
@@ -37,6 +37,7 @@ const PROFILE_URL = config.get('PROFILE_URL', '')
 
 const ProfileInformation = (props: Props) => {
   const { profile, isSocialClientReady, loggedInAddress, profileAddress, isBlockedByLoggedUser, hasBlockedLoggedUser, onViewMore } = props
+  console.log({ loggedInAddress, profileAddress, profile })
 
   const [hasCopiedLink, setHasCopiedLink] = useTimer(1200)
   const [hasCopiedWallet, setHasCopiedWallet] = useTimer(1200)
@@ -82,7 +83,7 @@ const ProfileInformation = (props: Props) => {
 
   const isLoggedInProfile = loggedInAddress === profileAddress
   const avatarName = getAvatarName(avatar)
-  const shouldShowFriendsButton = !isLoggedInProfile && loggedInAddress && isSocialClientReady
+  const shouldShowFriendsButton = (loggedInAddress && !isLoggedInProfile && isSocialClientReady) || !loggedInAddress
   const isBlocked = !isLoggedInProfile && (isBlockedByLoggedUser || hasBlockedLoggedUser)
   const shouldShowViewMoreButton =
     (hasAboutInformation(avatar) || (avatar?.description?.length ?? 0) > MAX_DESCRIPTION_LENGTH) && !isBlocked
@@ -112,7 +113,9 @@ const ProfileInformation = (props: Props) => {
           {!isBlocked && (
             // The class name is needed to avoid the display block of the div. The div is just for testing purposes
             <div data-testid={actionsForNonBlockedTestId} className={styles.displayContents}>
-              {shouldShowFriendsButton ? <FriendshipButton className={styles.friendsButton} friendAddress={profileAddress} /> : null}
+              {shouldShowFriendsButton ? (
+                <FriendshipButton className={styles.friendsButton} friendAddress={profileAddress} isLoggedIn={Boolean(loggedInAddress)} />
+              ) : null}
               {loggedInAddress && !isTabletAndBelow ? <WorldsButton isLoggedIn={isLoggedInProfile} address={profileAddress} /> : null}
               {hasCopiedLink && <span className={styles.copiedLink}>{t('profile_information.copied')}</span>}
               <Dropdown

--- a/src/modules/social/actions.ts
+++ b/src/modules/social/actions.ts
@@ -8,8 +8,8 @@ export const fetchFriendsSuccess = createAction<string[]>('[Success] Fetch Frien
 export const fetchFriendsFailure = createAction<string>('[Failure] Fetch Friends')
 
 export type FetchFriendsRequestAction = ReturnType<typeof fetchFriendsRequest>
-export type FetchFriendsSuccess = ReturnType<typeof fetchFriendsSuccess>
-export type FetchFriendsFailure = ReturnType<typeof fetchFriendsFailure>
+export type FetchFriendsSuccessAction = ReturnType<typeof fetchFriendsSuccess>
+export type FetchFriendsFailureAction = ReturnType<typeof fetchFriendsFailure>
 
 // Fetch friend requests events actions
 
@@ -52,6 +52,7 @@ export const fetchMutualFriendsFailure = createAction<string>('[Failure] Fetch M
 export type FetchMutualFriendsRequestAction = ReturnType<typeof fetchMutualFriendsRequest>
 export type FetchMutualFriendsSuccessAction = ReturnType<typeof fetchMutualFriendsSuccess>
 export type FetchMutualFriendsFailureAction = ReturnType<typeof fetchMutualFriendsFailure>
+
 // Request friendship
 
 export const requestFriendshipRequest = createAction<string>('[Request] Request Friendship')
@@ -61,6 +62,12 @@ export const requestFriendshipFailure = createAction<string>('[Failure] Request 
 export type RequestFriendshipRequestAction = ReturnType<typeof requestFriendshipRequest>
 export type RequestFriendshipSuccessAction = ReturnType<typeof requestFriendshipSuccess>
 export type RequestFriendshipFailureAction = ReturnType<typeof requestFriendshipFailure>
+
+// Log in and request friendship
+
+export const logInAndRequestFriendshipRequest = createAction<string>('[Request] Log In And Request Friendship')
+
+export type LogInAndRequestFriendshipRequestAction = ReturnType<typeof logInAndRequestFriendshipRequest>
 
 // Remove friends
 

--- a/src/modules/social/sagas.ts
+++ b/src/modules/social/sagas.ts
@@ -1,5 +1,7 @@
-import { takeEvery, call, put } from 'redux-saga/effects'
+import { takeEvery, call, put, race, take, select } from 'redux-saga/effects'
 import { isErrorWithMessage } from 'decentraland-dapps/dist/lib/error'
+import { CLOSE_MODAL, CloseModalAction, openModal } from 'decentraland-dapps/dist/modules/modal/actions'
+import { CONNECT_WALLET_SUCCESS, ConnectWalletSuccessAction } from 'decentraland-dapps/dist/modules/wallet/actions'
 import { LoginSuccessAction, loginSuccess } from '../identity/action'
 import {
   cancelFriendshipRequestRequest,
@@ -34,10 +36,13 @@ import {
   removeFriendSuccess,
   rejectFriendshipFailure,
   rejectFriendshipRequest,
-  rejectFriendshipSuccess
+  rejectFriendshipSuccess,
+  LogInAndRequestFriendshipRequestAction,
+  logInAndRequestFriendshipRequest
 } from './actions'
 import { getClient, getFriends, getMutualFriends, initiateSocialClient } from './client'
-import { RequestEvent, SocialClient } from './types'
+import { getFriendshipStatus } from './selectors'
+import { FriendshipStatus, RequestEvent, SocialClient } from './types'
 
 export function* socialSagas() {
   yield takeEvery(loginSuccess.type, handleStartSocialServiceConnection)
@@ -46,6 +51,7 @@ export function* socialSagas() {
   yield takeEvery(cancelFriendshipRequestRequest.type, handleCancelFriendshipRequest)
   yield takeEvery(fetchMutualFriendsRequest.type, handleFetchMutualFriendsRequests)
   yield takeEvery(requestFriendshipRequest.type, handleRequestFriendship)
+  yield takeEvery(logInAndRequestFriendshipRequest.type, handleLogInAndRequestFriendshipRequest)
   yield takeEvery(removeFriendRequest.type, handleRemoveFriend)
   yield takeEvery(acceptFriendshipRequest.type, handleAcceptFriendRequest)
   yield takeEvery(rejectFriendshipRequest.type, handleRejectFriendRequest)
@@ -164,6 +170,51 @@ export function* socialSagas() {
       yield put(rejectFriendshipSuccess(action.payload.toLowerCase()))
     } catch (error) {
       yield put(rejectFriendshipFailure(isErrorWithMessage(error) ? error.message : 'Unknown'))
+    }
+  }
+
+  function* handleLogInAndRequestFriendshipRequest(action: LogInAndRequestFriendshipRequestAction) {
+    const friendAddress = action.payload
+
+    yield put(openModal('LoginModal'))
+
+    const {
+      success,
+      close
+    }: {
+      success: ConnectWalletSuccessAction
+      close: CloseModalAction
+    } = yield race({
+      success: take(CONNECT_WALLET_SUCCESS),
+      close: take(CLOSE_MODAL)
+    })
+
+    if (close || (success && success.payload.wallet.address.toLowerCase() === friendAddress)) {
+      return
+    }
+
+    const { failureInitializingSocialClient } = yield race({
+      initializeSocialClientSuccess: take(initializeSocialClientSuccess.type),
+      initializeSocialClientFailure: take(initializeSocialClientFailure.type)
+    })
+
+    if (failureInitializingSocialClient) {
+      return
+    }
+
+    const { failureFetchingFriends } = yield race({
+      successFetchingFriends: take(fetchFriendsSuccess.type),
+      failureFetchingFriends: take(fetchFriendsFailure.type)
+    })
+
+    if (failureFetchingFriends) {
+      return
+    }
+
+    const friendshipStatus: ReturnType<typeof getFriendshipStatus> = yield select(getFriendshipStatus, friendAddress)
+
+    if (friendshipStatus === FriendshipStatus.NOT_FRIEND) {
+      yield put(requestFriendshipRequest(friendAddress))
     }
   }
 }


### PR DESCRIPTION
This PR changes the way the `FriendshipButton` behaves by showing it if the user is not connected to the dApp. When clicking on it, it will be prompted to log in and after that, a request to ask the user being viewed for friendship will be launched.
![Screenshot 2023-09-13 at 15 44 18](https://github.com/decentraland/profile/assets/1120791/f52a078c-0310-493c-bc86-d09d4dd763a3)
![Screenshot 2023-09-13 at 15 44 12](https://github.com/decentraland/profile/assets/1120791/dd5cb0f4-d154-4b92-9c29-4a0a10a959ac)

Closes #129