### PR TITLE
feat: Make empty errors according to categories

### DIFF
--- a/src/components/Creations/Creations.spec.tsx
+++ b/src/components/Creations/Creations.spec.tsx
@@ -121,28 +121,12 @@ describe('when rendering the component without items', () => {
   describe('and the view is of the own user', () => {
     beforeEach(() => {
       view = View.OWN
+      renderedComponent = renderCreations({ items, view }, ['/creations?category=wearable'])
     })
 
-    describe('and the category is of a wearable', () => {
-      beforeEach(() => {
-        renderedComponent = renderCreations({ items, view }, ['/creations?category=wearable'])
-      })
-
-      it('should render a message saying that the user does not have wearables created', () => {
-        const { getByText } = renderedComponent
-        expect(getByText(t('creations.own_empty_wearables_title'))).toBeInTheDocument()
-      })
-    })
-
-    describe('and the category is emotes', () => {
-      beforeEach(() => {
-        renderedComponent = renderCreations({ items, view }, ['/creations?category=emote'])
-      })
-
-      it('should render a message saying that the user does not have emotes created', () => {
-        const { getByText } = renderedComponent
-        expect(getByText(t('creations.own_empty_emotes_title'))).toBeInTheDocument()
-      })
+    it('should render a message saying that the user does not have wearables created', () => {
+      const { getByText } = renderedComponent
+      expect(getByText(t('creations.own_empty_title', { category: t('categories.wearable').toLowerCase() }))).toBeInTheDocument()
     })
   })
 
@@ -152,28 +136,14 @@ describe('when rendering the component without items', () => {
     beforeEach(() => {
       view = View.OTHER
       profileName = 'aName'
+      renderedComponent = renderCreations({ items, view, profileName }, ['/creations?category=wearable'])
     })
 
-    describe('and the category is wearables', () => {
-      beforeEach(() => {
-        renderedComponent = renderCreations({ items, view, profileName }, ['/creations?category=wearable'])
-      })
-
-      it('should render a message saying that the user does not have wearables created', () => {
-        const { getByText } = renderedComponent
-        expect(getByText(t('creations.other_empty_wearables_title', { name: profileName }))).toBeInTheDocument()
-      })
-    })
-
-    describe('and the category is emotes', () => {
-      beforeEach(() => {
-        renderedComponent = renderCreations({ items, view, profileName }, ['/creations?category=emote'])
-      })
-
-      it('should render a message saying that the user does not have emotes created', () => {
-        const { getByText } = renderedComponent
-        expect(getByText(t('creations.other_empty_emotes_title', { name: profileName }))).toBeInTheDocument()
-      })
+    it('should render a message saying that the user does not have wearables created', () => {
+      const { getByText } = renderedComponent
+      expect(
+        getByText(t('creations.other_empty_title', { name: profileName, category: t('categories.wearable').toLowerCase() }))
+      ).toBeInTheDocument()
     })
   })
 })

--- a/src/components/Creations/Creations.tsx
+++ b/src/components/Creations/Creations.tsx
@@ -138,10 +138,17 @@ const Creations = (props: Props) => {
                 <div className={styles.image}>
                   <img src={selectedCategoryName === 'wearables' ? shirtImage : emoteImage} />
                 </div>
-                <h2 className={styles.title}>{t(`creations.${view}_empty_${selectedCategoryName}_title`, { name: profileName })}</h2>
+                <h2 className={styles.title}>
+                  {t(`creations.${view}_empty_title`, {
+                    name: profileName,
+                    category: t(`categories.${category}`).toLowerCase()
+                  })}
+                </h2>
                 {view === View.OWN ? (
                   <>
-                    <p className={styles.text}>{t(`creations.own_empty_${selectedCategoryName}_text`, { br: () => <br></br> })}</p>
+                    <p className={styles.text}>
+                      {t('creations.own_empty_text', { br: () => <br></br>, category: t(`categories.${category}`).toLowerCase() })}
+                    </p>
                     <div className={styles.actions}>
                       <Button
                         secondary

--- a/src/modules/translation/locales/en.json
+++ b/src/modules/translation/locales/en.json
@@ -146,14 +146,11 @@
   },
   "creations": {
     "items_count": "{count} {count, plural, one {item} other {items}}",
-    "own_empty_wearables_title": "You haven't created any Wearables yet",
-    "own_empty_emotes_title": "You haven't created any Emotes yet",
-    "own_empty_wearables_text": "Submit your first collection and become a Decentraland creator! <br></br> Create awesome wearables and monetize your creations",
-    "own_empty_emotes_text": "Submit your first collection and become a Decentraland creator! <br></br> Create awesome emotes and monetize your creations",
+    "own_empty_title": "You haven't created any {category} yet",
+    "own_empty_text": "Submit your first collection and become a Decentraland creator! <br></br> Create awesome {category} and monetize your creations",
     "own_empty_primary_action": "Learn more",
     "own_empty_secondary_action": "Create a collection",
-    "other_empty_wearables_title": "{name} hasn't created any Wearables yet",
-    "other_empty_emotes_title": "{name} hasn't created any Emotes yet"
+    "other_empty_title": "{name} hasn't created any {category} yet"
   },
   "filters_modal": {
     "title": "Filters",

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -143,7 +143,7 @@
   "creations": {
     "items_count": "{count} {count, plural, one {item} other {items}}",
     "own_empty_title": "Aún no has creado ningún {category}",
-    "own_empty_text": "¡Envíe su primera colección y conviértase en descentral y creador!<br> </br> Crea {category} increíbles y monetiza tus creaciones",
+    "own_empty_text": "¡Envíe su primera colección y conviértase en un creador de Decentraland!<br> </br> Crea {category} increíbles y monetiza tus creaciones",
     "own_empty_primary_action": "Aprende más",
     "own_empty_secondary_action": "Crear una colección",
     "other_empty_title": "{name} todavía no creó ningún {category}"

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -142,14 +142,11 @@
   },
   "creations": {
     "items_count": "{count} {count, plural, one {item} other {items}}",
-    "own_empty_wearables_title": "Aún no has creado ningún wearable",
-    "own_empty_emotes_title": "Aún no has creado ningún emote",
-    "own_empty_wearables_text": "¡Envíe su primera colección y conviértase en descentral y creador!<br> </br> Crea wearables increíbles y monetiza tus creaciones",
-    "own_empty_emotes_text": "¡Envíe su primera colección y conviértase en descentral y creador!<br> </br> Crea emotes increíbles y monetiza tus creaciones",
+    "own_empty_title": "Aún no has creado ningún {category}",
+    "own_empty_text": "¡Envíe su primera colección y conviértase en descentral y creador!<br> </br> Crea {category} increíbles y monetiza tus creaciones",
     "own_empty_primary_action": "Aprende más",
     "own_empty_secondary_action": "Crear una colección",
-    "other_empty_wearables_title": "{name} todavía no creó ningún wearable",
-    "other_empty_emotes_title": "{nombre} no creó ningún emote"
+    "other_empty_title": "{name} todavía no creó ningún {category}"
   },
   "filters_modal": {
     "title": "Filtros",

--- a/src/modules/translation/locales/zh.json
+++ b/src/modules/translation/locales/zh.json
@@ -141,14 +141,12 @@
     "cheapest": "最低价"
   },
   "creations": {
-    "own_empty_wearables_title": "您还没有创建任何可穿戴设备",
-    "own_empty_emotes_title": "您还没有创造任何情绪",
-    "own_empty_wearables_text": "提交您的第一个收藏品并成为去分散的创作者！<br> </br>创建很棒的可穿戴设备并将您的作品货币化",
-    "own_empty_emotes_text": "提交您的第一个收藏品并成为去分散的创作者！<br> </br>创造出色的情感并使您的创作获利",
+    "items_count": "{count} {count, plural, one {item} other {items}}",
+    "own_empty_title": "您尚未创建任何{category}",
+    "own_empty_text": "提交您的第一个收藏并成为 Decentraland 创造者！ <br></br> 创造精彩的{category}并通过您的创作获利",
     "own_empty_primary_action": "了解更多",
     "own_empty_secondary_action": "创建一个集合",
-    "other_empty_wearables_title": "{名称}还没有创建任何可穿戴设备",
-    "other_empty_emotes_title": "{name}还没有创造任何情绪"
+    "other_empty_title": "{name} 尚未创建任何 {category}"
   },
   "filters_modal": {
     "filters": "过滤器",


### PR DESCRIPTION
This PR makes the empty errors or dialog show the category the user selected on the filters for the Creations tab as it's done for the Assets one.