### PR TITLE
fix: Creations sorting changing other filters

### DIFF
--- a/src/components/Creations/Creations.spec.tsx
+++ b/src/components/Creations/Creations.spec.tsx
@@ -484,7 +484,7 @@ describe('when changing the sorting', () => {
   it('should re-trigger the creations fetch with the selected sort', () => {
     const { getByText } = renderedComponent
     act(() => {
-      fireEvent.click(getByText(t(`items_sort_by.${ItemSortBy.CHEAPEST}`)))
+      fireEvent.click(getByText(t(`catalog_sort_by.${ItemSortBy.CHEAPEST}`)))
     })
     expect(onFetchCreations).toHaveBeenCalledWith({
       creator: '0x1',

--- a/src/components/Creations/Creations.tsx
+++ b/src/components/Creations/Creations.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
-import { Rarity, ItemSortBy } from '@dcl/schemas'
+import { Rarity, CatalogSortBy } from '@dcl/schemas'
 import { AssetStatus, AssetStatusFilter, SmartWearableFilter } from 'decentraland-dapps/dist/containers'
 import { AssetCard } from 'decentraland-dapps/dist/containers/AssetCard/AssetCard'
 import { RarityFilter } from 'decentraland-dapps/dist/containers/RarityFilter'
@@ -41,7 +41,7 @@ const Creations = (props: Props) => {
   const isMobile = useMobileMediaQuery()
   const { page, first, sortBy, filters, hasMorePages, goToPage, changeFilter, changeFilters, changeSorting } = usePagination<
     keyof Options,
-    ItemSortBy
+    CatalogSortBy
   >({
     pageSize: ITEMS_PER_PAGE,
     count
@@ -51,7 +51,7 @@ const Creations = (props: Props) => {
   const [rarities, getRaritiesQueryString] = useRaritiesFilter(filters.rarities)
   const [status, , getAssetStatusQueryString] = useAssetStatusFilter(filters.status)
   const selectedCategoryName = useMemo(() => getCategoryName(category), [category])
-  const selectedSortBy = sortBy ?? ItemSortBy.NEWEST
+  const selectedSortBy = sortBy ?? CatalogSortBy.NEWEST
   const hasFiltersEnabled = Boolean(sortBy || filters.category || filters.rarities)
 
   useEffect(() => {
@@ -99,10 +99,10 @@ const Creations = (props: Props) => {
     [getCategoriesQueryString, changeFilter]
   )
   const handleSortByChange = useCallback(
-    (value: ItemSortBy) => {
+    (value: CatalogSortBy) => {
       changeSorting(value)
     },
-    [changeFilter]
+    [changeSorting]
   )
   const handleChangeStatus = useCallback(
     (value: AssetStatus) => {

--- a/src/components/Creations/utils.ts
+++ b/src/components/Creations/utils.ts
@@ -1,4 +1,4 @@
-import { ItemSortBy } from '@dcl/schemas'
+import { CatalogSortBy } from '@dcl/schemas'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { ItemCategory } from '../../modules/items/types'
 import { MainCategory, AccessoryCategory, WearableCategory, EmoteCategory, HeadCategory } from '../../utils/categories'
@@ -36,7 +36,7 @@ export function buildCategoryFilterCategories() {
 }
 
 export function buildSortByOptions() {
-  return Object.values(ItemSortBy).map(value => ({ value, text: t(`items_sort_by.${value}`) }))
+  return Object.values(CatalogSortBy).map(value => ({ value, text: t(`catalog_sort_by.${value}`) }))
 }
 
 export function getCategoryName(category: ItemCategory): 'emotes' | 'wearables' {

--- a/src/components/InformationBar/InformationBar.spec.tsx
+++ b/src/components/InformationBar/InformationBar.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
-import { ItemSortBy } from '@dcl/schemas'
+import { CatalogSortBy } from '@dcl/schemas'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { useMobileMediaQuery } from 'decentraland-ui/dist/components/Media/Media'
 import { renderWithProviders } from '../../tests/tests'
@@ -15,10 +15,10 @@ jest.mock('decentraland-ui/dist/components/Media/Media', () => ({
 
 const useMobileMediaQueryMock = useMobileMediaQuery as jest.MockedFunction<typeof useMobileMediaQuery>
 
-function renderInformationBar(props: Partial<Props<ItemSortBy>> = {}) {
+function renderInformationBar(props: Partial<Props<CatalogSortBy>> = {}) {
   return renderWithProviders(
     <InformationBar
-      sortBy={ItemSortBy.NAME}
+      sortBy={CatalogSortBy.CHEAPEST}
       sortByOptions={buildSortByOptions()}
       getCountText={count => count.toString()}
       onSortByChange={jest.fn()}
@@ -92,8 +92,8 @@ describe('when changing the sorting options', () => {
 
   it('should call the onSortByChange prop method with the new sort option', () => {
     const { getByText } = renderedComponent
-    fireEvent.click(getByText(t(`catalog_sort_by.${ItemSortBy.RECENTLY_LISTED}`)))
-    expect(onSortByChange).toHaveBeenCalledWith(ItemSortBy.RECENTLY_LISTED)
+    fireEvent.click(getByText(t(`catalog_sort_by.${CatalogSortBy.RECENTLY_LISTED}`)))
+    expect(onSortByChange).toHaveBeenCalledWith(CatalogSortBy.RECENTLY_LISTED)
   })
 })
 

--- a/src/components/InformationBar/InformationBar.spec.tsx
+++ b/src/components/InformationBar/InformationBar.spec.tsx
@@ -92,7 +92,7 @@ describe('when changing the sorting options', () => {
 
   it('should call the onSortByChange prop method with the new sort option', () => {
     const { getByText } = renderedComponent
-    fireEvent.click(getByText(t(`items_sort_by.${ItemSortBy.RECENTLY_LISTED}`)))
+    fireEvent.click(getByText(t(`catalog_sort_by.${ItemSortBy.RECENTLY_LISTED}`)))
     expect(onSortByChange).toHaveBeenCalledWith(ItemSortBy.RECENTLY_LISTED)
   })
 })

--- a/src/components/InformationBar/InformationBar.tsx
+++ b/src/components/InformationBar/InformationBar.tsx
@@ -10,9 +10,12 @@ const InformationBar = <T extends string>(props: Props<T>) => {
   const { count, sortBy, sortByOptions, isLoading, className, hasFiltersEnabled, getCountText, onSortByChange, onOpenFiltersModal } = props
   const isMobile = useMobileMediaQuery()
 
-  const handleOnSortChange = useCallback((_: unknown, props: DropdownProps) => {
-    onSortByChange(props.value as T)
-  }, [])
+  const handleOnSortChange = useCallback(
+    (_: unknown, props: DropdownProps) => {
+      onSortByChange(props.value as T)
+    },
+    [onSortByChange]
+  )
 
   return (
     <div className={classNames(styles.infoRow, className)}>

--- a/src/components/Modals/CreationsFiltersModal/CreationsFiltersModal.tsx
+++ b/src/components/Modals/CreationsFiltersModal/CreationsFiltersModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { ItemSortBy, Rarity } from '@dcl/schemas'
+import { CatalogSortBy, Rarity } from '@dcl/schemas'
 import { AssetStatus, AssetStatusFilter, SmartWearableFilter } from 'decentraland-dapps/dist/containers'
 import { RarityFilter } from 'decentraland-dapps/dist/containers/RarityFilter'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -15,7 +15,7 @@ import { Props } from './CreationsFiltersModal.types'
 import styles from './CreationsFiltersModal.module.css'
 
 const CreationsFiltersModal = (props: Props) => {
-  const { filters, changeFilters } = usePagination<keyof Options, ItemSortBy>({
+  const { filters, changeFilters } = usePagination<keyof Options, CatalogSortBy>({
     pageSize: ITEMS_PER_PAGE
   })
   const [category, getCategoriesQueryString] = useCategoriesFilter(filters.category)

--- a/src/modules/items/client.spec.ts
+++ b/src/modules/items/client.spec.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import { Item, ItemSortBy, Network, Rarity } from '@dcl/schemas'
+import { CatalogSortBy, Item, Network, Rarity } from '@dcl/schemas'
 import { EmoteCategory, MainCategory, WearableCategory } from '../../utils/categories'
 import { ItemsClient } from './client'
 import { Options, ItemSaleStatus } from './types'
@@ -21,7 +21,7 @@ describe.each<[string, Options, string]>([
   ['network', { network: Network.MATIC }, 'network=MATIC'],
   ['creator', { creator: 'aCreator' }, 'creator=aCreator'],
   ['rarities', { rarities: [Rarity.COMMON, Rarity.EPIC] }, 'rarity=common&rarity=epic'],
-  ['sortBy', { sortBy: ItemSortBy.NAME }, 'sortBy=name'],
+  ['sortBy', { sortBy: CatalogSortBy.CHEAPEST }, 'sortBy=cheapest'],
   ['isWearableSmart', { isWearableSmart: true }, 'isWearableSmart=true']
 ])('when requesting items with the %s option', (type, options, queryString) => {
   beforeEach(() => {

--- a/src/modules/items/types.ts
+++ b/src/modules/items/types.ts
@@ -1,10 +1,10 @@
-import { ItemFilters } from '@dcl/schemas'
+import { CatalogFilters } from '@dcl/schemas'
 import { AccessoryCategory, EmoteCategory, HeadCategory, MainCategory, WearableCategory } from '../../utils/categories'
 
 export type CreationsFetchOptions = Omit<Options, 'creator'> & Required<Pick<Options, 'creator'>>
 
 export type Options = Pick<
-  ItemFilters,
+  CatalogFilters,
   'first' | 'skip' | 'creator' | 'ids' | 'network' | 'urns' | 'rarities' | 'isWearableSmart' | 'sortBy'
 > & {
   category?: ItemCategory

--- a/src/modules/translation/locales/en.json
+++ b/src/modules/translation/locales/en.json
@@ -136,13 +136,12 @@
   "categories_menu": {
     "title": "Categories"
   },
-  "items_sort_by": {
-    "name": "Name",
+  "catalog_sort_by": {
     "newest": "Newest",
-    "recently_reviewed": "Recently reviewed",
     "recently_sold": "Recently sold",
-    "recently_listed": "Recently listed",
-    "cheapest": "Cheapest"
+    "cheapest": "Cheapest",
+    "most_expensive": "Most expensive",
+    "recently_listed": "Recently listed"
   },
   "creations": {
     "items_count": "{count} {count, plural, one {item} other {items}}",

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -132,13 +132,12 @@
   "categories_menu": {
     "title": "Categorías"
   },
-  "items_sort_by": {
-    "name": "Nombre",
+  "catalog_sort_by": {
     "newest": "Más nuevos",
-    "recently_reviewed": "Revisado recientemente",
     "recently_sold": "Vendidos recientemente",
-    "recently_listed": "Listados recientemente",
-    "cheapest": "Más baratos"
+    "cheapest": "Más baratos",
+    "most_expensive": "Más caros",
+    "recently_listed": "Listados recientemente"
   },
   "creations": {
     "items_count": "{count} {count, plural, one {item} other {items}}",

--- a/src/modules/translation/locales/zh.json
+++ b/src/modules/translation/locales/zh.json
@@ -132,13 +132,12 @@
   "categories_menu": {
     "title": "类别"
   },
-  "items_sort_by": {
-    "name": "名称",
+  "catalog_sort_by": {
     "newest": "最新",
-    "recently_reviewed": "最近审查",
     "recently_sold": "最近售出",
-    "recently_listed": "最新上市",
-    "cheapest": "最低价"
+    "cheapest": "最低价",
+    "most_expensive": "最貴",
+    "recently_listed": "最新上市"
   },
   "creations": {
     "items_count": "{count} 项目}",


### PR DESCRIPTION
This PR fixes two issues:
1. The filters for the creations tab were incorrect, the ones that should be displayed are the ones for the Catalog endpoint, which is the one used for the creations.
2. The sorting function was not correctly included in the dependencies for the callback hooks, preventing it from correctly setting the sorting option when executing the function (it changed it but without taking into consideration the new filters).