### PR TITLE
fix: Typos and tabs

### DIFF
--- a/src/components/Creations/Creations.spec.tsx
+++ b/src/components/Creations/Creations.spec.tsx
@@ -139,7 +139,8 @@ describe('when rendering the component without items', () => {
           expect(
             getByText(
               t('creations.own_empty_main_category_title', {
-                category: t(`categories.${category}`).toLocaleLowerCase()
+                category: t(`categories.${category}`).toLocaleLowerCase(),
+                parentCategory: t(`categories.${parentCategory}`)
               })
             )
           ).toBeInTheDocument()
@@ -158,7 +159,8 @@ describe('when rendering the component without items', () => {
           expect(
             getByText(
               t('creations.own_empty_main_category_title', {
-                category: t(`categories.${category}`).toLocaleLowerCase()
+                category: t(`categories.${category}`).toLocaleLowerCase(),
+                parentCategory: t(`categories.${parentCategory}`)
               })
             )
           ).toBeInTheDocument()
@@ -178,7 +180,7 @@ describe('when rendering the component without items', () => {
             getByText(
               t('creations.own_empty_sub_category_title', {
                 category: t(`categories.${category}`).toLocaleLowerCase(),
-                parentCategory: t(`categories.${parentCategory}`).toLocaleLowerCase()
+                parentCategory: t(`categories.${parentCategory}`)
               })
             )
           ).toBeInTheDocument()
@@ -198,7 +200,7 @@ describe('when rendering the component without items', () => {
             getByText(
               t('creations.own_empty_sub_category_title', {
                 category: t(`categories.${category}`).toLocaleLowerCase(),
-                parentCategory: t(`categories.${parentCategory}`).toLocaleLowerCase()
+                parentCategory: t(`categories.${parentCategory}`)
               })
             )
           ).toBeInTheDocument()
@@ -251,7 +253,8 @@ describe('when rendering the component without items', () => {
             getByText(
               t('creations.other_empty_main_category_title', {
                 name: profileName,
-                category: t(`categories.${category}`).toLocaleLowerCase()
+                category: t(`categories.${category}`).toLocaleLowerCase(),
+                parentCategory: t(`categories.${parentCategory}`)
               })
             )
           ).toBeInTheDocument()
@@ -271,7 +274,8 @@ describe('when rendering the component without items', () => {
             getByText(
               t('creations.other_empty_main_category_title', {
                 name: profileName,
-                category: t(`categories.${category}`).toLocaleLowerCase()
+                category: t(`categories.${category}`).toLocaleLowerCase(),
+                parentCategory: t(`categories.${parentCategory}`)
               })
             )
           ).toBeInTheDocument()
@@ -292,7 +296,7 @@ describe('when rendering the component without items', () => {
               t('creations.other_empty_sub_category_title', {
                 name: profileName,
                 category: t(`categories.${category}`).toLocaleLowerCase(),
-                parentCategory: t(`categories.${parentCategory}`).toLocaleLowerCase()
+                parentCategory: t(`categories.${parentCategory}`)
               })
             )
           ).toBeInTheDocument()
@@ -313,7 +317,7 @@ describe('when rendering the component without items', () => {
               t('creations.other_empty_sub_category_title', {
                 name: profileName,
                 category: t(`categories.${category}`).toLocaleLowerCase(),
-                parentCategory: t(`categories.${parentCategory}`).toLocaleLowerCase()
+                parentCategory: t(`categories.${parentCategory}`)
               })
             )
           ).toBeInTheDocument()

--- a/src/components/Creations/Creations.tsx
+++ b/src/components/Creations/Creations.tsx
@@ -137,7 +137,7 @@ const Creations = (props: Props) => {
               ? t(`creations.${view}_empty_${isMainCategory ? 'main' : 'sub'}_category_title`, {
                   name: profileName,
                   category: t(`categories.${category}`).toLocaleLowerCase(),
-                  parentCategory: t(`categories.${parentCategory}`).toLocaleLowerCase()
+                  parentCategory: t(`categories.${parentCategory}`)
                 })
               : t('creations.empty_multiple_filters_title')}
           </h2>
@@ -146,7 +146,7 @@ const Creations = (props: Props) => {
               <p className={styles.text}>
                 {t(`creations.own_empty_${isMainCategory ? 'main' : 'sub'}_category_text`, {
                   category: t(`categories.${category}`).toLowerCase(),
-                  parentCategory: t(`categories.${parentCategory}`).toLocaleLowerCase()
+                  parentCategory: t(`categories.${parentCategory}`)
                 })}
               </p>
               <div className={isMainCategory ? styles.mainCategoryActions : styles.subCategoryActions}>

--- a/src/components/Pages/MainPage/MainPage.spec.tsx
+++ b/src/components/Pages/MainPage/MainPage.spec.tsx
@@ -42,18 +42,41 @@ let screen: RenderResult
 
 describe('when the creations tab FF is enabled', () => {
   let mainTabsCmp: ReturnType<typeof within>
+  let profileAddress: string
+  let loggedInAddress: string
 
-  beforeEach(() => {
-    screen = renderMainPage({ isCreationsTabEnabled: true })
-    mainTabsCmp = within(screen.getByTestId('main-tabs'))
+  describe('and the user is viewing its own profile', () => {
+    beforeEach(() => {
+      profileAddress = '0xaddress'
+      loggedInAddress = profileAddress
+      screen = renderMainPage({ isCreationsTabEnabled: true, loggedInAddress, profileAddress })
+      mainTabsCmp = within(screen.getByTestId('main-tabs'))
+    })
+
+    it('should show the overview tab', () => {
+      expect(mainTabsCmp.getByText(t('tabs.overview'))).toBeInTheDocument()
+    })
+
+    it('should show the "My Creations" tab', async () => {
+      expect(mainTabsCmp.getByText(t('tabs.own_creations'))).toBeInTheDocument()
+    })
   })
 
-  it('should show the creations tab', async () => {
-    expect(mainTabsCmp.getByText(t('tabs.creations'))).toBeInTheDocument()
-  })
+  describe('and the user is viewing another profile', () => {
+    beforeEach(() => {
+      profileAddress = '0xaddress'
+      loggedInAddress = 'anotherAddress'
+      screen = renderMainPage({ isCreationsTabEnabled: true, loggedInAddress, profileAddress })
+      mainTabsCmp = within(screen.getByTestId('main-tabs'))
+    })
 
-  it('should show the overview tab', () => {
-    expect(mainTabsCmp.getByText(t('tabs.overview'))).toBeInTheDocument()
+    it('should show the overview tab', () => {
+      expect(mainTabsCmp.getByText(t('tabs.overview'))).toBeInTheDocument()
+    })
+
+    it('should show the "Creations" tab', async () => {
+      expect(mainTabsCmp.getByText(t('tabs.others_creations'))).toBeInTheDocument()
+    })
   })
 })
 
@@ -69,22 +92,45 @@ describe('when the creations tab FF is disabled', () => {
 
 describe('when the assets tab FF is enabled', () => {
   let mainTabsCmp: ReturnType<typeof within>
+  let profileAddress: string
+  let loggedInAddress: string
 
-  beforeEach(() => {
-    screen = renderMainPage({ isAssetsTabEnabled: true })
-    mainTabsCmp = within(screen.getByTestId('main-tabs'))
+  describe('and the user is viewing its own profile', () => {
+    beforeEach(() => {
+      profileAddress = '0xaddress'
+      loggedInAddress = profileAddress
+      screen = renderMainPage({ isAssetsTabEnabled: true, loggedInAddress, profileAddress })
+      mainTabsCmp = within(screen.getByTestId('main-tabs'))
+    })
+
+    it('should show the overview tab', () => {
+      expect(mainTabsCmp.getByText(t('tabs.overview'))).toBeInTheDocument()
+    })
+
+    it('should show the "My Assets" tab', () => {
+      expect(mainTabsCmp.getByText(t('tabs.own_assets'))).toBeInTheDocument()
+    })
   })
 
-  it('should show the assets tab', () => {
-    expect(mainTabsCmp.getByText(t('tabs.assets'))).toBeInTheDocument()
-  })
+  describe('and the user is viewing another profile', () => {
+    beforeEach(() => {
+      profileAddress = '0xaddress'
+      loggedInAddress = 'anotherAddress'
+      screen = renderMainPage({ isAssetsTabEnabled: true, loggedInAddress, profileAddress })
+      mainTabsCmp = within(screen.getByTestId('main-tabs'))
+    })
 
-  it('should show the overview tab', () => {
-    expect(mainTabsCmp.getByText(t('tabs.overview'))).toBeInTheDocument()
+    it('should show the "Assets" tab', () => {
+      expect(mainTabsCmp.getByText(t('tabs.others_assets'))).toBeInTheDocument()
+    })
+
+    it('should show the overview tab', () => {
+      expect(mainTabsCmp.getByText(t('tabs.overview'))).toBeInTheDocument()
+    })
   })
 })
 
-describe('when the assets tab FF is disable', () => {
+describe('when the assets tab FF is disabled', () => {
   beforeEach(() => {
     screen = renderMainPage({ isAssetsTabEnabled: false })
   })

--- a/src/components/Pages/MainPage/MainPage.tsx
+++ b/src/components/Pages/MainPage/MainPage.tsx
@@ -47,10 +47,10 @@ function MainPage(props: Props) {
         ? [{ displayValue: view === View.OWN ? t('tabs.own_assets') : t('tabs.others_assets'), value: AccountTabs.ASSETS }]
         : []),
       ...(isCreationsTabEnabled
-        ? [{ displayValue: view === View.OWN ? t('tabs.own_creations') : t('tabs.own_creations'), value: AccountTabs.CREATIONS }]
+        ? [{ displayValue: view === View.OWN ? t('tabs.own_creations') : t('tabs.others_creations'), value: AccountTabs.CREATIONS }]
         : [])
     ],
-    [isAssetsTabEnabled, isCreationsTabEnabled]
+    [isAssetsTabEnabled, isCreationsTabEnabled, view]
   )
 
   const handleTabChange = useCallback((tab: AccountTabs) => {

--- a/src/components/Pages/MainPage/MainPage.tsx
+++ b/src/components/Pages/MainPage/MainPage.tsx
@@ -8,7 +8,7 @@ import { Tabs } from 'decentraland-ui/dist/components/Tabs/Tabs'
 import usePageTracking from '../../../hooks/usePageTracking'
 import { isTabValid, locations } from '../../../modules/routing/locations'
 import { AccountTabs } from '../../../modules/routing/types'
-import { getView } from '../../../utils/view'
+import { View, getView } from '../../../utils/view'
 import { Assets } from '../../Assets'
 import { Avatar } from '../../Avatar'
 import { BlockedUser } from '../../BlockedUser'
@@ -43,8 +43,12 @@ function MainPage(props: Props) {
   const tabs: { displayValue: string; value: AccountTabs }[] = useMemo(
     () => [
       { displayValue: t('tabs.overview'), value: AccountTabs.OVERVIEW },
-      ...(isAssetsTabEnabled ? [{ displayValue: t('tabs.assets'), value: AccountTabs.ASSETS }] : []),
-      ...(isCreationsTabEnabled ? [{ displayValue: t('tabs.creations'), value: AccountTabs.CREATIONS }] : [])
+      ...(isAssetsTabEnabled
+        ? [{ displayValue: view === View.OWN ? t('tabs.own_assets') : t('tabs.others_assets'), value: AccountTabs.ASSETS }]
+        : []),
+      ...(isCreationsTabEnabled
+        ? [{ displayValue: view === View.OWN ? t('tabs.own_creations') : t('tabs.own_creations'), value: AccountTabs.CREATIONS }]
+        : [])
     ],
     [isAssetsTabEnabled, isCreationsTabEnabled]
   )

--- a/src/modules/translation/locales/en.json
+++ b/src/modules/translation/locales/en.json
@@ -30,12 +30,11 @@
     "jump": "Jump to \"{domain}\" World"
   },
   "tabs": {
-    "assets": "Assets",
-    "creations": "Creations",
-    "dao_activity": "DAO Activity",
-    "lists": "Lists",
     "overview": "Overview",
-    "places": "Places"
+    "own_assets": "My Assets",
+    "others_assets": "Assets",
+    "own_creations": "My Creations",
+    "others_creations": "Creations"
   },
   "friendship_button": {
     "friends": "Friends",
@@ -59,9 +58,9 @@
   "overview": {
     "title": "Equipped Collectibles",
     "start_dressing": "Start dressing in ways beyond your imagination ",
-    "get_collectibles": "Get your first collectible wereable and rock it in Decentraland!",
+    "get_collectibles": "Get your first collectible Wearable and rock it in Decentraland!",
     "go_to_marketplace": "go to marketplace",
-    "no_collectibles": " doesn't have any collectible wearables yet."
+    "no_collectibles": " doesn't have any collectible Wearables yet."
   },
   "about_modal": {
     "title": "About",
@@ -145,9 +144,9 @@
   },
   "creations": {
     "items_count": "{count} {count, plural, one {item} other {items}}",
-    "own_empty_main_category_title": "You haven't created any {category} yet",
+    "own_empty_main_category_title": "You haven't created any {parentCategory} yet",
     "own_empty_sub_category_title": "No {category} {parentCategory} found",
-    "other_empty_main_category_title": "{name} hasn't created any {category} yet",
+    "other_empty_main_category_title": "{name} hasn't created any {parentCategory} yet",
     "other_empty_sub_category_title": "{name} hasn't created any {category} {parentCategory} yet",
     "empty_multiple_filters_title": "No results found for these filters",
     "own_empty_main_category_text": "Unleash your creativity and start earning from your own designs!",

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -31,11 +31,10 @@
   },
   "tabs": {
     "overview": "Resumen",
-    "assets": "Objetos",
-    "creations": "Creaciones",
-    "lists": "Listas",
-    "dao_activity": "Actividad DAO",
-    "places": "Places"
+    "own_assets": "Mis assets",
+    "others_assets": "Assets",
+    "own_creations": "Mis creaciones",
+    "others_creations": "Creaciones"
   },
   "friendship_button": {
     "friends": "Amigos",
@@ -145,9 +144,9 @@
   },
   "creations": {
     "items_count": "{count} {count, plural, one {item} other {items}}",
-    "own_empty_main_category_title": "No has creado ningún {category} todavía",
+    "own_empty_main_category_title": "No has creado ningún {parentCategory} todavía",
     "own_empty_sub_category_title": "No se encontró ningún {parentCategory} de {category}",
-    "other_empty_main_category_title": "{name} no ha creado ningún {category} todavía",
+    "other_empty_main_category_title": "{name} no ha creado ningún {parentCategory} todavía",
     "other_empty_sub_category_title": "{name} no ha creado ningún {parentCategory} de {category} todavía",
     "empty_multiple_filters_title": "No se ha encontrado ningún resultado para éstos filtros",
     "own_empty_main_category_text": "¡Libera tu creatividad y comienza a ganar de tus propios diseños!",

--- a/src/modules/translation/locales/zh.json
+++ b/src/modules/translation/locales/zh.json
@@ -31,11 +31,10 @@
   },
   "tabs": {
     "overview": "概述",
-    "assets": "資產",
-    "creations": "創作",
-    "lists": "列表",
-    "dao_activity": "DAO 活動",
-    "places": "地點"
+    "own_assets": "我的资产",
+    "others_assets": "资产",
+    "own_creations": "我的创作",
+    "others_creations": "创作"
   },
   "friendship_button": {
     "friends": "朋友们",
@@ -145,9 +144,9 @@
   },
   "creations": {
     "items_count": "{count} 项目}",
-    "own_empty_main_category_title": "您尚未创建任何{category}",
+    "own_empty_main_category_title": "您尚未创建任何{parentCategory}",
     "own_empty_sub_category_title": "找不到{category} {parentCategory}",
-    "other_empty_main_category_title": "{name} 尚未创建任何 {category}",
+    "other_empty_main_category_title": "{name} 尚未创建任何 {parentCategory}",
     "other_empty_sub_category_title": "{name} 尚未创建任何 {category} {parentCategory}",
     "empty_multiple_filters_title": "没有找到这些过滤器的结果",
     "own_empty_main_category_text": "释放您的创造力并开始从您自己的设计中赚钱！",


### PR DESCRIPTION
This PR does the following:
- Changes the code so that the main categories (Wearables & Emotes) are capitalized
- Changes the english translations to make the Wearables & Emotes categories capitalized.
- Changes the code so that when the user gets into the their profile, the tabs will say "My Assets" and "My Creations" instead of "Assets" and "Creations" which they would normally say.