### PR TITLE
fix: Move error out of wearable preview div

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -51,11 +51,11 @@ const Avatar = (props: Props) => {
             profile={profileAddress}
             disableDefaultWearables
           />
-          {(!profile && view === View.OWN && !isLoadingWearablePreview) || isError ? (
-            <div data-testid="avatar-message" className={styles.message}>
-              {t('avatar.message')}
-            </div>
-          ) : null}
+        </div>
+      ) : null}
+      {(!profile && view === View.OWN && !isLoadingWearablePreview) || isError ? (
+        <div data-testid="avatar-message" className={styles.message}>
+          {t('avatar.message')}
         </div>
       ) : null}
       {view === View.OWN && (


### PR DESCRIPTION
This PR moves the error message out of the wearable preview div, preventing it from overstretching behind the main div.
![Screenshot 2024-01-04 at 09 24 28](https://github.com/decentraland/profile/assets/1120791/7f79ea85-2671-4a25-afd3-1dcc99d620a7)
![Screenshot 2024-01-04 at 09 27 24](https://github.com/decentraland/profile/assets/1120791/71cc63a1-bce3-4980-b8bb-72e067a5a828)
