### PR TITLE
fix: Overview and avatar preview

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -43,7 +43,6 @@ const Avatar = (props: Props) => {
           <WearablePreview
             onLoad={handleOnLoad}
             onError={handleError}
-            onUpdate={handleOnLoad}
             panning={false}
             lockBeta={true}
             dev={config.getEnv() === Env.DEVELOPMENT}

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -15,7 +15,6 @@ const MARKETPLACE_URL = config.get('MARKETPLACE_URL', '')
 
 const Overview = (props: Props) => {
   const { isLoading, items, onFetchItems, wearableIds, className, profileAddress, loggedInAddress, profile } = props
-  console.log('Wearable ids', wearableIds, isLoading)
   const isLoggedInProfile = profileAddress === loggedInAddress
   const avatarName = useMemo(() => getAvatarName(profile?.avatars[0]).name, [profile])
 

--- a/src/components/Overview/Overview.tsx
+++ b/src/components/Overview/Overview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useMemo, useEffect } from 'react'
 import classNames from 'classnames'
 import { Item } from '@dcl/schemas'
 import { AssetCard } from 'decentraland-dapps/dist/containers/AssetCard/AssetCard'
@@ -15,15 +15,15 @@ const MARKETPLACE_URL = config.get('MARKETPLACE_URL', '')
 
 const Overview = (props: Props) => {
   const { isLoading, items, onFetchItems, wearableIds, className, profileAddress, loggedInAddress, profile } = props
-
+  console.log('Wearable ids', wearableIds, isLoading)
   const isLoggedInProfile = profileAddress === loggedInAddress
-  const avatarName = getAvatarName(profile?.avatars[0]).name
+  const avatarName = useMemo(() => getAvatarName(profile?.avatars[0]).name, [profile])
 
   useEffect(() => {
     if (wearableIds.length > 0) {
       onFetchItems(wearableIds)
     }
-  }, [wearableIds])
+  }, [wearableIds.length])
 
   return (
     <div className={classNames(className, styles.Overview)} data-testid="overview">

--- a/src/modules/items/selectors.spec.ts
+++ b/src/modules/items/selectors.spec.ts
@@ -108,7 +108,14 @@ describe('when getting the wearable urns of a given profile', () => {
 
   describe('and the profile exists', () => {
     it('should return the wearable urns of the user items', () => {
-      expect(getProfileWearableUrns(state, address)).toEqual(state.profile.data[address].avatars[0].avatar.wearables)
+      expect(getProfileWearableUrns(state, address)).toEqual([
+        'urn:decentraland:ethereum:collections-v1:community_contest:cw_casinovisor_hat',
+        'urn:decentraland:ethereum:collections-v1:dg_summer_2020:dg_mink_fur_coat_upper_body',
+        'urn:decentraland:matic:collections-v2:0x213efc9acb3f51cdb7ca208fb28b49e792441107',
+        'urn:decentraland:matic:collections-v2:0x62e9f0f793164a2edbd4dc739e3b53da623c8944',
+        'urn:decentraland:matic:collections-v2:0x9d9b55db299c46e5118675361d4a5a2ba49b54b6',
+        'urn:decentraland:matic:collections-v2:0xc25744bed31b2ae67e349a8ef59dfa48e064140f'
+      ])
     })
   })
 })

--- a/src/modules/items/selectors.spec.ts
+++ b/src/modules/items/selectors.spec.ts
@@ -109,6 +109,11 @@ describe('when getting the wearable urns of a given profile', () => {
   describe('and the profile exists', () => {
     it('should return the wearable urns of the user items', () => {
       expect(getProfileWearableUrns(state, address)).toEqual([
+        'urn:decentraland:off-chain:base-avatars:eyebrows_00',
+        'urn:decentraland:off-chain:base-avatars:casual_hair_01',
+        'urn:decentraland:off-chain:base-avatars:eyes_05',
+        'urn:decentraland:off-chain:base-avatars:mouth_06',
+        'urn:decentraland:off-chain:base-avatars:handlebar',
         'urn:decentraland:ethereum:collections-v1:community_contest:cw_casinovisor_hat',
         'urn:decentraland:ethereum:collections-v1:dg_summer_2020:dg_mink_fur_coat_upper_body',
         'urn:decentraland:matic:collections-v2:0x213efc9acb3f51cdb7ca208fb28b49e792441107',

--- a/src/modules/items/selectors.ts
+++ b/src/modules/items/selectors.ts
@@ -3,7 +3,7 @@ import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors
 import { getData as getProfiles } from 'decentraland-dapps/dist/modules/profile/selectors'
 import { RootState } from '../reducer'
 import { fetchCreationsRequest, fetchItemsByUrnRequest } from './actions'
-import { getWearableUrnWithoutId } from './utils'
+import { removeIdFromWearableUrn } from './utils'
 
 const getState = (state: RootState) => state.items
 const getLoading = (state: RootState) => getState(state).loading
@@ -14,6 +14,5 @@ export const isLoadingItems = createSelector([getLoading], loadingState => isLoa
 export const isLoadingCreations = createSelector([getLoading], loadingState => isLoadingType(loadingState, fetchCreationsRequest.type))
 export const getProfileWearableUrns = createSelector(
   [getProfiles, (_state, address) => address],
-  (profiles, address) =>
-    (profiles[address]?.avatars[0]?.avatar.wearables.map((urn: string) => getWearableUrnWithoutId(urn)).filter(Boolean) as string[]) ?? []
+  (profiles, address) => profiles[address]?.avatars[0]?.avatar.wearables.map((urn: string) => removeIdFromWearableUrn(urn)) ?? []
 )

--- a/src/modules/items/selectors.ts
+++ b/src/modules/items/selectors.ts
@@ -3,6 +3,7 @@ import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors
 import { getData as getProfiles } from 'decentraland-dapps/dist/modules/profile/selectors'
 import { RootState } from '../reducer'
 import { fetchCreationsRequest, fetchItemsByUrnRequest } from './actions'
+import { getWearableUrnWithoutId } from './utils'
 
 const getState = (state: RootState) => state.items
 const getLoading = (state: RootState) => getState(state).loading
@@ -13,5 +14,6 @@ export const isLoadingItems = createSelector([getLoading], loadingState => isLoa
 export const isLoadingCreations = createSelector([getLoading], loadingState => isLoadingType(loadingState, fetchCreationsRequest.type))
 export const getProfileWearableUrns = createSelector(
   [getProfiles, (_state, address) => address],
-  (profiles, address) => profiles[address]?.avatars[0]?.avatar.wearables ?? []
+  (profiles, address) =>
+    (profiles[address]?.avatars[0]?.avatar.wearables.map((urn: string) => getWearableUrnWithoutId(urn)).filter(Boolean) as string[]) ?? []
 )

--- a/src/modules/items/utils.spec.ts
+++ b/src/modules/items/utils.spec.ts
@@ -1,0 +1,73 @@
+import { removeIdFromWearableUrn, isEthereumWearable, isMaticWearable } from './utils'
+
+describe('when checking if a urn belongs to a matic wearable', () => {
+  let urn: string
+
+  describe('and the urn belongs to a matic wearable', () => {
+    beforeEach(() => {
+      urn = 'urn:decentraland:matic:collections-v2:0xc25744bed31b2ae67e349a8ef59dfa48e064140f:0'
+    })
+
+    it('should return true', () => {
+      expect(isMaticWearable(urn)).toBe(true)
+    })
+  })
+
+  describe('and the urn does not belong to a matic wearable', () => {
+    beforeEach(() => {
+      urn = 'urn:decentraland:ethereum:collections-v1:community_contest:cw_casinovisor_hat'
+    })
+
+    it('should return false', () => {
+      expect(isMaticWearable(urn)).toBe(false)
+    })
+  })
+})
+
+describe('when checking if a urn belongs to a ethereum wearable', () => {
+  let urn: string
+
+  describe('and the urn belongs to a ethereum wearable', () => {
+    beforeEach(() => {
+      urn = 'urn:decentraland:ethereum:collections-v1:community_contest:cw_casinovisor_hat'
+    })
+
+    it('should return true', () => {
+      expect(isEthereumWearable(urn)).toBe(true)
+    })
+  })
+
+  describe('and the urn does not belong to a ethereum wearable', () => {
+    beforeEach(() => {
+      urn = 'urn:decentraland:matic:collections-v2:0xc25744bed31b2ae67e349a8ef59dfa48e064140f:0'
+    })
+
+    it('should return false', () => {
+      expect(isEthereumWearable(urn)).toBe(false)
+    })
+  })
+})
+
+describe('when removing the id from a wearable urn', () => {
+  let urn: string
+
+  describe('and the wearable is not a collection-v2 wearable', () => {
+    beforeEach(() => {
+      urn = 'urn:decentraland:off-chain:base-avatars:eyebrows_00'
+    })
+
+    it('should return the same urn', () => {
+      expect(removeIdFromWearableUrn(urn)).toBe(urn)
+    })
+  })
+
+  describe('and the wearable is a collection-v2 wearable', () => {
+    beforeEach(() => {
+      urn = 'urn:decentraland:matic:collections-v2:0xc25744bed31b2ae67e349a8ef59dfa48e064140f:0'
+    })
+
+    it('should return the urn without its id', () => {
+      expect(removeIdFromWearableUrn(urn)).toBe('urn:decentraland:matic:collections-v2:0xc25744bed31b2ae67e349a8ef59dfa48e064140f')
+    })
+  })
+})

--- a/src/modules/items/utils.ts
+++ b/src/modules/items/utils.ts
@@ -1,4 +1,4 @@
-const wearablesRegex = /^urn:decentraland:(.+):(collections-v[12]):(.+):(.+)(:(.+))?$/
+const wearablesRegex = /^urn:decentraland:(.+):(collections-v[12]):(.+):(.+)(:([0-9]+))?$/
 
 export const isEthereumWearable = (urn: string): boolean => {
   const result = wearablesRegex.exec(urn)
@@ -21,5 +21,11 @@ export const getWearableUrnWithoutId = (urn: string): string | null => {
   if (!result || (result && result.length < 4)) {
     return null
   }
-  return `urn:decentraland:${result[1]}:${result[2]}:${result[3]}`
+
+  // Remove the ID from the URN
+  if (result[2] === 'collections-v2') {
+    return `urn:decentraland:${result[1]}:${result[2]}:${result[3]}`
+  }
+
+  return urn
 }

--- a/src/modules/items/utils.ts
+++ b/src/modules/items/utils.ts
@@ -16,16 +16,12 @@ export const isMaticWearable = (urn: string): boolean => {
   return result[1] === 'matic' || result[1] === 'mumbai'
 }
 
-export const getWearableUrnWithoutId = (urn: string): string | null => {
+export const removeIdFromWearableUrn = (urn: string): string => {
   const result = wearablesRegex.exec(urn)
-  if (!result || (result && result.length < 4)) {
-    return null
+  if (!result || (result && result.length < 4) || (result && result[2] !== 'collections-v2')) {
+    return urn
   }
 
   // Remove the ID from the URN
-  if (result[2] === 'collections-v2') {
-    return `urn:decentraland:${result[1]}:${result[2]}:${result[3]}`
-  }
-
-  return urn
+  return `urn:decentraland:${result[1]}:${result[2]}:${result[3]}`
 }

--- a/src/modules/items/utils.ts
+++ b/src/modules/items/utils.ts
@@ -1,4 +1,4 @@
-export const wearablesRegex = /^urn:decentraland:(.+):collections-v[12]:(.+):(.+)$/
+const wearablesRegex = /^urn:decentraland:(.+):(collections-v[12]):(.+):(.+)(:(.+))?$/
 
 export const isEthereumWearable = (urn: string): boolean => {
   const result = wearablesRegex.exec(urn)
@@ -14,4 +14,12 @@ export const isMaticWearable = (urn: string): boolean => {
     return false
   }
   return result[1] === 'matic' || result[1] === 'mumbai'
+}
+
+export const getWearableUrnWithoutId = (urn: string): string | null => {
+  const result = wearablesRegex.exec(urn)
+  if (!result || (result && result.length < 4)) {
+    return null
+  }
+  return `urn:decentraland:${result[1]}:${result[2]}:${result[3]}`
 }


### PR DESCRIPTION
This PR fixes the following:
- An unwanted early trigger of the `handleOnLoad` callback on the `Avatar` component which set the wearable preview as loaded when it wasn't.
- The overview site not loading the items because they got their ID appended to their URN.
- An unwanted double trigger of the fetch to get the overview items (due to the comparison of an array).