### PR TITLE
feat: add image from reward already granted

### DIFF
--- a/src/components/Referrals/ReferralJourney/ReferralJourney.container.tsx
+++ b/src/components/Referrals/ReferralJourney/ReferralJourney.container.tsx
@@ -6,7 +6,9 @@ import { ReferralJourney } from './ReferralJourney'
 import { MapStateProps, MapDispatch, MapDispatchProps, OwnProps } from './ReferralJourney.types'
 
 const mapState = (_: RootState, ownProps: OwnProps): MapStateProps => ({
-  invitedUsersAccepted: ownProps.invitedUsersAccepted
+  invitedUsersAccepted: ownProps.invitedUsersAccepted,
+  invitedUsersAcceptedViewed: ownProps.invitedUsersAcceptedViewed,
+  rewardImages: ownProps.rewardImages
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps =>

--- a/src/components/Referrals/ReferralJourney/ReferralJourney.spec.tsx
+++ b/src/components/Referrals/ReferralJourney/ReferralJourney.spec.tsx
@@ -50,7 +50,15 @@ describe('ReferralJourney', () => {
   let renderedComponent: ReturnType<typeof renderReferralJourney>
 
   const renderReferralJourney = (props: Partial<ReferralJourneyProps>) => {
-    return renderWithProviders(<ReferralJourney invitedUsersAccepted={invitedUsersAccepted} onSetReferralEmail={jest.fn()} {...props} />)
+    return renderWithProviders(
+      <ReferralJourney
+        invitedUsersAccepted={invitedUsersAccepted}
+        invitedUsersAcceptedViewed={0}
+        rewardImages={[]}
+        onSetReferralEmail={jest.fn()}
+        {...props}
+      />
+    )
   }
 
   beforeEach(() => {

--- a/src/components/Referrals/ReferralJourney/ReferralJourney.tsx
+++ b/src/components/Referrals/ReferralJourney/ReferralJourney.tsx
@@ -25,7 +25,7 @@ import { AnimationPhase as AnimationPhase, ReferralJourneyProps } from './Referr
 const ReferralJourney = React.memo((props: ReferralJourneyProps) => {
   const { invitedUsersAccepted, invitedUsersAcceptedViewed, onSetReferralEmail, rewardImages } = props
 
-  const [animatedStep, setAnimatedStep] = useState(TIERS.filter(tier => tier.invitesAccepted <= invitedUsersAccepted).length)
+  const [animatedStep, setAnimatedStep] = useState(getTiersCompletedCount(invitedUsersAccepted))
   const [open, setOpen] = useState(false)
   const [journeyTiers, setJourneyTiers] = useState(
     TIERS.map(tier => ({ ...tier, completed: tier.invitesAccepted <= invitedUsersAccepted }))
@@ -72,7 +72,7 @@ const ReferralJourney = React.memo((props: ReferralJourneyProps) => {
   useEffect(() => {
     const currentAnimatedStep = getTiersCompletedCount(invitedUsersAccepted)
     setAnimatedStep(currentAnimatedStep)
-  }, [invitedUsersAccepted, getTiersCompletedCount])
+  }, [])
 
   useEffect(() => {
     const newTiersToAnimate = getNewTiersToAnimate()

--- a/src/components/Referrals/ReferralJourney/ReferralJourney.tsx
+++ b/src/components/Referrals/ReferralJourney/ReferralJourney.tsx
@@ -72,7 +72,7 @@ const ReferralJourney = React.memo((props: ReferralJourneyProps) => {
   useEffect(() => {
     const currentAnimatedStep = getTiersCompletedCount(invitedUsersAccepted)
     setAnimatedStep(currentAnimatedStep)
-  }, [])
+  }, [invitedUsersAccepted, getTiersCompletedCount])
 
   useEffect(() => {
     const newTiersToAnimate = getNewTiersToAnimate()

--- a/src/components/Referrals/ReferralJourney/ReferralJourney.types.ts
+++ b/src/components/Referrals/ReferralJourney/ReferralJourney.types.ts
@@ -8,11 +8,15 @@ enum AnimationPhase {
 
 type ReferralJourneyProps = {
   invitedUsersAccepted: number
+  invitedUsersAcceptedViewed: number
+  rewardImages: { tier: number; url: string }[]
   onSetReferralEmail: (email: string) => unknown
 }
 
 type MapStateProps = {
   invitedUsersAccepted: number
+  invitedUsersAcceptedViewed: number
+  rewardImages: { tier: number; url: string }[]
 }
 
 type MapDispatch = Dispatch
@@ -23,6 +27,8 @@ type MapDispatchProps = {
 
 type OwnProps = {
   invitedUsersAccepted: number
+  invitedUsersAcceptedViewed: number
+  rewardImages: { tier: number; url: string }[]
 }
 
 export { AnimationPhase }

--- a/src/components/Referrals/ReferralJourney/utils.spec.ts
+++ b/src/components/Referrals/ReferralJourney/utils.spec.ts
@@ -1,0 +1,92 @@
+import { TIERS } from './constants'
+import { getTiersCompletedCount, calculateProgressPercentage } from './utils'
+
+describe('calculateProgressPercentage', () => {
+  describe('when totalSteps is 0', () => {
+    it('should return 0', () => {
+      const result = calculateProgressPercentage(0, 5)
+      expect(result).toBe(0)
+    })
+  })
+
+  describe('when totalSteps is negative', () => {
+    it('should return 0', () => {
+      const result = calculateProgressPercentage(-1, 5)
+      expect(result).toBe(0)
+    })
+  })
+
+  describe('when invitedUsersAccepted is at the first tier', () => {
+    it('should return the exact number of invites', () => {
+      const result = calculateProgressPercentage(9, 5)
+      expect(result).toBe(5)
+    })
+  })
+
+  describe('when invitedUsersAccepted is below first tier', () => {
+    it('should return the exact number of invites', () => {
+      const result = calculateProgressPercentage(9, 3)
+      expect(result).toBe(3)
+    })
+  })
+
+  describe('when invitedUsersAccepted is at the last tier', () => {
+    it('should return maximum percentage', () => {
+      const result = calculateProgressPercentage(9, 100)
+      expect(result).toBeCloseTo(99.9, 1)
+    })
+  })
+
+  describe('when invitedUsersAccepted is above the last tier', () => {
+    it('should return maximum percentage', () => {
+      const result = calculateProgressPercentage(9, 150)
+      expect(result).toBeCloseTo(99.9, 1)
+    })
+  })
+
+  describe('when invitedUsersAccepted is between tier thresholds', () => {
+    it('should calculate correct percentage', () => {
+      const result = calculateProgressPercentage(9, 7)
+      expect(result).toBeCloseTo(9.44, 1)
+    })
+  })
+
+  describe('when invitedUsersAccepted is exactly at a tier threshold', () => {
+    it('should calculate correct percentage', () => {
+      const result = calculateProgressPercentage(9, 30)
+      expect(result).toBeCloseTo(49.4, 1)
+    })
+  })
+})
+
+describe('getTiersCompletedCount', () => {
+  describe('when the user has no invites accepted', () => {
+    it('should return 0 completed tiers', () => {
+      const result = getTiersCompletedCount(0)
+      expect(result).toBe(0)
+    })
+  })
+
+  TIERS.forEach((tier, index: number) => {
+    describe(`when the user has exactly ${tier.invitesAccepted} invites accepted`, () => {
+      it(`should return ${index + 1} completed tier${index + 1 === 1 ? '' : 's'}`, () => {
+        const result = getTiersCompletedCount(tier.invitesAccepted)
+        expect(result).toBe(index + 1)
+      })
+    })
+  })
+
+  describe('when the user has more than 100 invites accepted', () => {
+    it('should return 9 completed tiers', () => {
+      const result = getTiersCompletedCount(150)
+      expect(result).toBe(9)
+    })
+  })
+
+  describe('when the user has invites between tier thresholds', () => {
+    it('should return the correct number of completed tiers', () => {
+      const result = getTiersCompletedCount(7)
+      expect(result).toBe(1)
+    })
+  })
+})

--- a/src/components/Referrals/ReferralJourney/utils.ts
+++ b/src/components/Referrals/ReferralJourney/utils.ts
@@ -1,35 +1,24 @@
-import { TIERS } from './constants'
-
 const ANIMATION_DURATION = 800
 
 const SEGMENT_PERCENTAGE = 11.1
 const OFFSET = 5
 
-const calculateProgressPercentage = (totalSteps: number, invitedUsersAccepted: number): number => {
+const calculateProgressPercentage = (totalSteps: number, activeStep: number): number => {
   if (totalSteps <= 0) return 0
 
-  if (invitedUsersAccepted <= TIERS[0].invitesAccepted) {
-    return invitedUsersAccepted
+  // Si activeStep es 0, no hay progreso
+  if (activeStep <= 0) {
+    return 0
   }
 
-  if (invitedUsersAccepted >= TIERS[TIERS.length - 1].invitesAccepted) {
+  // Si activeStep es igual o mayor al total de steps, está completo
+  if (activeStep >= totalSteps) {
     return totalSteps * SEGMENT_PERCENTAGE
   }
 
-  let prevTierIndex = 0
-  for (let i = 0; i < TIERS.length; i++) {
-    if (invitedUsersAccepted < TIERS[i].invitesAccepted) {
-      prevTierIndex = i - 1
-      break
-    }
-  }
-  const prevTier = TIERS[prevTierIndex]
-  const nextTier = TIERS[prevTierIndex + 1]
-  const invitesNeeded = nextTier.invitesAccepted - prevTier.invitesAccepted
-  const invitesProgress = invitedUsersAccepted - prevTier.invitesAccepted
-  const progressPercentage = (invitesProgress / invitesNeeded) * SEGMENT_PERCENTAGE
-  const basePercentage = prevTierIndex * SEGMENT_PERCENTAGE + OFFSET
-  return basePercentage + progressPercentage
+  // Calcular el progreso basado en activeStep
+  const basePercentage = (activeStep - 1) * SEGMENT_PERCENTAGE + OFFSET
+  return basePercentage
 }
 
 export { ANIMATION_DURATION, calculateProgressPercentage }

--- a/src/components/Referrals/ReferralJourney/utils.ts
+++ b/src/components/Referrals/ReferralJourney/utils.ts
@@ -1,24 +1,39 @@
+import { TIERS } from './constants'
+
 const ANIMATION_DURATION = 800
 
 const SEGMENT_PERCENTAGE = 11.1
 const OFFSET = 5
 
-const calculateProgressPercentage = (totalSteps: number, activeStep: number): number => {
+const calculateProgressPercentage = (totalSteps: number, invitedUsersAccepted: number): number => {
   if (totalSteps <= 0) return 0
 
-  // Si activeStep es 0, no hay progreso
-  if (activeStep <= 0) {
-    return 0
+  if (invitedUsersAccepted <= TIERS[0].invitesAccepted) {
+    return invitedUsersAccepted
   }
 
-  // Si activeStep es igual o mayor al total de steps, está completo
-  if (activeStep >= totalSteps) {
+  if (invitedUsersAccepted >= TIERS[TIERS.length - 1].invitesAccepted) {
     return totalSteps * SEGMENT_PERCENTAGE
   }
 
-  // Calcular el progreso basado en activeStep
-  const basePercentage = (activeStep - 1) * SEGMENT_PERCENTAGE + OFFSET
-  return basePercentage
+  let prevTierIndex = 0
+  for (let i = 0; i < TIERS.length; i++) {
+    if (invitedUsersAccepted < TIERS[i].invitesAccepted) {
+      prevTierIndex = i - 1
+      break
+    }
+  }
+  const prevTier = TIERS[prevTierIndex]
+  const nextTier = TIERS[prevTierIndex + 1]
+  const invitesNeeded = nextTier.invitesAccepted - prevTier.invitesAccepted
+  const invitesProgress = invitedUsersAccepted - prevTier.invitesAccepted
+  const progressPercentage = (invitesProgress / invitesNeeded) * SEGMENT_PERCENTAGE
+  const basePercentage = prevTierIndex * SEGMENT_PERCENTAGE + OFFSET
+  return basePercentage + progressPercentage
 }
 
-export { ANIMATION_DURATION, calculateProgressPercentage }
+const getTiersCompletedCount = (invitedUsersAccepted: number): number => {
+  return TIERS.filter(tier => tier.invitesAccepted <= invitedUsersAccepted).length
+}
+
+export { ANIMATION_DURATION, calculateProgressPercentage, getTiersCompletedCount }

--- a/src/components/Referrals/Referrals.container.ts
+++ b/src/components/Referrals/Referrals.container.ts
@@ -3,13 +3,14 @@ import { bindActionCreators } from '@reduxjs/toolkit'
 import { getIsReferralTestingButtonEnabled } from '../../modules/features/selectors'
 import { RootState } from '../../modules/reducer'
 import { fetchReferralsRequest } from '../../modules/referrals/actions'
-import { getInvitedUsersAccepted, getInvitedUsersAcceptedViewed } from '../../modules/referrals/selectors'
+import { getInvitedUsersAccepted, getInvitedUsersAcceptedViewed, getRewardGrantedImages } from '../../modules/referrals/selectors'
 import Referrals from './Referrals'
 import { MapStateProps, MapDispatch, MapDispatchProps, OwnProps } from './Referrals.types'
 
 const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => ({
   invitedUsersAccepted: getInvitedUsersAccepted(state),
   invitedUsersAcceptedViewed: getInvitedUsersAcceptedViewed(state),
+  rewardGrantedImages: getRewardGrantedImages(state),
   profileAddress: ownProps.profileAddress,
   isReferralTestingButtonEnabled: getIsReferralTestingButtonEnabled(state)
 })

--- a/src/components/Referrals/Referrals.spec.tsx
+++ b/src/components/Referrals/Referrals.spec.tsx
@@ -21,6 +21,7 @@ describe('Referrals', () => {
       profileAddress: '0x123',
       invitedUsersAccepted: 0,
       invitedUsersAcceptedViewed: 0,
+      rewardGrantedImages: [],
       isReferralTestingButtonEnabled: false,
       onFetchReferrals: jest.fn() as unknown as Props['onFetchReferrals']
     }

--- a/src/components/Referrals/Referrals.spec.tsx
+++ b/src/components/Referrals/Referrals.spec.tsx
@@ -9,8 +9,10 @@ jest.mock('./ReferralHeroSection', () => ({
   ReferralHeroSection: () => <div data-testid={MOCK_HERO_SECTION_TEST_ID} />
 }))
 
-jest.mock('./ReferralJourney', () => ({
-  ReferralJourney: () => <div data-testid={MOCK_JOURNEY_TEST_ID} />
+jest.mock('./ReferralJourney/ReferralJourney.container', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: () => <div data-testid={MOCK_JOURNEY_TEST_ID} />
 }))
 
 describe('Referrals', () => {

--- a/src/components/Referrals/Referrals.tsx
+++ b/src/components/Referrals/Referrals.tsx
@@ -7,7 +7,14 @@ import { ReferralsContainer, ReferralJourneySectionContainer, ReferralHeroContai
 import { Props } from './Referrals.types'
 
 const Referrals = (props: Props) => {
-  const { profileAddress, onFetchReferrals, invitedUsersAccepted, isReferralTestingButtonEnabled } = props
+  const {
+    profileAddress,
+    onFetchReferrals,
+    invitedUsersAccepted,
+    invitedUsersAcceptedViewed,
+    rewardGrantedImages,
+    isReferralTestingButtonEnabled
+  } = props
 
   useEffect(() => {
     if (profileAddress) {
@@ -16,9 +23,11 @@ const Referrals = (props: Props) => {
   }, [profileAddress, onFetchReferrals])
 
   const [invitedUsers, setInvitedUsers] = useState<number>(0)
+  const [invitedUsersViewed, setInvitedUsersViewed] = useState<number>(0)
 
   useEffect(() => {
     setInvitedUsers(invitedUsersAccepted)
+    setInvitedUsersViewed(invitedUsersAcceptedViewed)
   }, [invitedUsersAccepted])
 
   return (
@@ -27,7 +36,11 @@ const Referrals = (props: Props) => {
         <ReferralHeroSection profileAddress={profileAddress} />
       </ReferralHeroContainer>
       <ReferralJourneySectionContainer data-testid={REFERRALS_JOURNEY_TEST_ID}>
-        <ReferralJourney invitedUsersAccepted={invitedUsers} />
+        <ReferralJourney
+          invitedUsersAccepted={invitedUsers}
+          invitedUsersAcceptedViewed={invitedUsersViewed}
+          rewardImages={rewardGrantedImages}
+        />
       </ReferralJourneySectionContainer>
       {isReferralTestingButtonEnabled && <Button onClick={() => setInvitedUsers(invitedUsers + 1)}>Test adding invited user</Button>}
     </ReferralsContainer>

--- a/src/components/Referrals/Referrals.tsx
+++ b/src/components/Referrals/Referrals.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Button } from 'decentraland-ui2'
 import { REFERRALS_CONTAINER_TEST_ID, REFERRALS_HERO_SECTION_TEST_ID, REFERRALS_JOURNEY_TEST_ID } from './constants'
 import { ReferralHeroSection } from './ReferralHeroSection'
-import { ReferralJourney } from './ReferralJourney'
+import ReferralJourney from './ReferralJourney/ReferralJourney.container'
 import { ReferralsContainer, ReferralJourneySectionContainer, ReferralHeroContainer } from './Referrals.styled'
 import { Props } from './Referrals.types'
 

--- a/src/components/Referrals/Referrals.types.ts
+++ b/src/components/Referrals/Referrals.types.ts
@@ -5,13 +5,14 @@ export type Props = {
   profileAddress: string
   invitedUsersAccepted: number
   invitedUsersAcceptedViewed: number
+  rewardGrantedImages: { tier: number; url: string }[]
   onFetchReferrals: typeof fetchReferralsRequest
   isReferralTestingButtonEnabled: boolean
 }
 
 export type MapStateProps = Pick<
   Props,
-  'profileAddress' | 'invitedUsersAccepted' | 'invitedUsersAcceptedViewed' | 'isReferralTestingButtonEnabled'
+  'profileAddress' | 'invitedUsersAccepted' | 'invitedUsersAcceptedViewed' | 'rewardGrantedImages' | 'isReferralTestingButtonEnabled'
 >
 export type MapDispatch = Dispatch
 export type MapDispatchProps = Pick<Props, 'onFetchReferrals'>

--- a/src/modules/referrals/client.spec.ts
+++ b/src/modules/referrals/client.spec.ts
@@ -9,7 +9,8 @@ beforeEach(() => {
   client = new ReferralsClient('https://example.com')
   referralProgress = {
     invitedUsersAccepted: 5,
-    invitedUsersAcceptedViewed: 3
+    invitedUsersAcceptedViewed: 3,
+    rewardImages: []
   }
 
   // Setup mock fetch

--- a/src/modules/referrals/reducer.spec.ts
+++ b/src/modules/referrals/reducer.spec.ts
@@ -111,7 +111,8 @@ describe('referrals reducer', () => {
       beforeEach(() => {
         mockData = {
           invitedUsersAccepted: 15,
-          invitedUsersAcceptedViewed: 12
+          invitedUsersAcceptedViewed: 12,
+          rewardImages: []
         }
         state = referralsReducer(state, fetchReferralsSuccess(mockData))
       })

--- a/src/modules/referrals/reducer.spec.ts
+++ b/src/modules/referrals/reducer.spec.ts
@@ -51,7 +51,13 @@ describe('referrals reducer', () => {
       beforeEach(() => {
         mockData = {
           invitedUsersAccepted: 5,
-          invitedUsersAcceptedViewed: 3
+          invitedUsersAcceptedViewed: 3,
+          rewardImages: [
+            {
+              tier: 5,
+              url: 'https://peer.decentraland.zone/lambdas/collections/contents/urn:decentraland:amoy:collections-v2:0x6d8a2b6753f59d909ffa7f38b01327c191e4bf60:0/thumbnail'
+            }
+          ]
         }
         state = referralsReducer(state, fetchReferralsSuccess(mockData))
       })
@@ -59,6 +65,7 @@ describe('referrals reducer', () => {
       it('should update the data with the response values', () => {
         expect(state.data.invitedUsersAccepted).toBe(5)
         expect(state.data.invitedUsersAcceptedViewed).toBe(3)
+        expect(state.data.rewardImages).toEqual(mockData.rewardImages)
       })
 
       it('should remove the request action from loading state', () => {
@@ -201,7 +208,13 @@ describe('referrals reducer', () => {
       currentState = {
         data: {
           invitedUsersAccepted: 5,
-          invitedUsersAcceptedViewed: 3
+          invitedUsersAcceptedViewed: 3,
+          rewardImages: [
+            {
+              tier: 5,
+              url: 'https://peer.decentraland.zone/lambdas/collections/contents/urn:decentraland:amoy:collections-v2:0x6d8a2b6753f59d909ffa7f38b01327c191e4bf60:0/thumbnail'
+            }
+          ]
         },
         loading: [],
         error: null

--- a/src/modules/referrals/reducer.ts
+++ b/src/modules/referrals/reducer.ts
@@ -19,7 +19,8 @@ export type ReferralsState = {
 export const buildInitialState = (): ReferralsState => ({
   data: {
     invitedUsersAccepted: 0,
-    invitedUsersAcceptedViewed: 0
+    invitedUsersAcceptedViewed: 0,
+    rewardImages: []
   },
   loading: [],
   error: null
@@ -35,6 +36,7 @@ export const referralsReducer = createReducer<ReferralsState>(buildInitialState(
       state.loading = loadingReducer(state.loading, action)
       state.data.invitedUsersAccepted = action.payload.invitedUsersAccepted
       state.data.invitedUsersAcceptedViewed = action.payload.invitedUsersAcceptedViewed
+      state.data.rewardImages = action.payload.rewardImages
     })
     .addCase(fetchReferralsFailure, (state, action) => {
       state.loading = loadingReducer(state.loading, action)

--- a/src/modules/referrals/sagas.spec.ts
+++ b/src/modules/referrals/sagas.spec.ts
@@ -23,7 +23,8 @@ describe('referrals sagas', () => {
     jest.spyOn(mockApi, 'setReferralEmail').mockImplementation(jest.fn())
     mockReferralData = {
       invitedUsersAccepted: 5,
-      invitedUsersAcceptedViewed: 3
+      invitedUsersAcceptedViewed: 3,
+      rewardImages: []
     }
   })
 
@@ -36,7 +37,8 @@ describe('referrals sagas', () => {
           .put(
             fetchReferralsSuccess({
               invitedUsersAccepted: 5,
-              invitedUsersAcceptedViewed: 3
+              invitedUsersAcceptedViewed: 3,
+              rewardImages: []
             })
           )
           .run()
@@ -103,14 +105,16 @@ describe('referrals sagas', () => {
         .put(
           fetchReferralsSuccess({
             invitedUsersAccepted: 5,
-            invitedUsersAcceptedViewed: 3
+            invitedUsersAcceptedViewed: 3,
+            rewardImages: []
           })
         )
         .dispatch(fetchReferralsRequest())
         .put(
           fetchReferralsSuccess({
             invitedUsersAccepted: 5,
-            invitedUsersAcceptedViewed: 3
+            invitedUsersAcceptedViewed: 3,
+            rewardImages: []
           })
         )
         .run()

--- a/src/modules/referrals/selectors.spec.ts
+++ b/src/modules/referrals/selectors.spec.ts
@@ -19,7 +19,8 @@ describe('referrals selectors', () => {
     mockReferralsState = {
       data: {
         invitedUsersAccepted: 5,
-        invitedUsersAcceptedViewed: 3
+        invitedUsersAcceptedViewed: 3,
+        rewardImages: []
       },
       loading: [],
       error: null
@@ -41,7 +42,8 @@ describe('referrals selectors', () => {
       const result = getData(mockState)
       expect(result).toEqual({
         invitedUsersAccepted: 5,
-        invitedUsersAcceptedViewed: 3
+        invitedUsersAcceptedViewed: 3,
+        rewardImages: []
       })
     })
   })

--- a/src/modules/referrals/selectors.ts
+++ b/src/modules/referrals/selectors.ts
@@ -8,5 +8,6 @@ export const getError = (state: RootState) => state.referrals.error
 
 export const getInvitedUsersAccepted = (state: RootState) => getData(state).invitedUsersAccepted
 export const getInvitedUsersAcceptedViewed = (state: RootState) => getData(state).invitedUsersAcceptedViewed
+export const getRewardGrantedImages = (state: RootState) => getData(state).rewardImages
 
 export const isLoadingReferrals = (state: RootState) => isLoadingType(getLoading(state), fetchReferralsRequest.type)

--- a/src/modules/referrals/types.ts
+++ b/src/modules/referrals/types.ts
@@ -13,4 +13,5 @@ export type { ReferralTier }
 export type ReferralProgressResponse = {
   invitedUsersAccepted: number
   invitedUsersAcceptedViewed: number
+  rewardImages: { tier: number; url: string }[]
 }


### PR DESCRIPTION
### Changes:

**Animation Logic:**
- Fixed animation to only trigger for new tiers between `invitedUsersAcceptedViewed` and `invitedUsersAccepted`

**Reward Images:**
- Added support for custom reward images from API
- Added fallback to default images when custom ones aren't available

The changes ensure animations only occur for newly reached tiers and reward images are properly displayed from API responses.