### PR TITLE
feat: update logic to download or jump in to world

### DIFF
--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -40,6 +40,10 @@
   position: relative;
 }
 
+.editButton {
+  width: 100%;
+}
+
 .editButton>img {
   margin-right: 5px;
 }

--- a/src/components/Avatar/Avatar.spec.tsx
+++ b/src/components/Avatar/Avatar.spec.tsx
@@ -5,6 +5,11 @@ import { renderWithProviders } from '../../tests/tests'
 import { View } from '../../utils/view'
 import Avatar from './Avatar'
 
+jest.mock('decentraland-ui2', () => ({
+  ...jest.requireActual('decentraland-ui2'),
+  JumpIn: (props: { buttonText?: string }) => <button>{props.buttonText ?? 'Jump In'}</button>
+}))
+
 describe('Avatar', () => {
   const anAddress = 'anAddress'
   const anotherAddress = 'anotherAddress'

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,15 +1,12 @@
 import React, { useCallback, useState } from 'react'
-import { Link } from 'react-router-dom'
 import classNames from 'classnames'
 import { Env } from '@dcl/ui-env'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Button } from 'decentraland-ui/dist/components/Button/Button'
 import { Loader } from 'decentraland-ui/dist/components/Loader/Loader'
 import { useTabletAndBelowMediaQuery } from 'decentraland-ui/dist/components/Media/Media'
 import { WearablePreview } from 'decentraland-ui/dist/components/WearablePreview/WearablePreview'
-import Edit from '../../assets/icons/Edit.svg'
+import { JumpIn } from 'decentraland-ui2'
 import { config } from '../../modules/config'
-import { getEditAvatarUrl } from '../../modules/routing/locations'
 import { View } from '../../utils/view'
 import { Props } from './Avatar.types'
 import styles from './Avatar.module.css'
@@ -61,17 +58,18 @@ const Avatar = (props: Props) => {
         </div>
       ) : null}
       {view === View.OWN && (
-        <Button
-          primary
-          fluid
-          className={classNames('customIconButton', styles.editButton)}
-          as={Link}
-          to={getEditAvatarUrl()}
-          target="_blank"
-        >
-          <img src={Edit} className="iconSize" />
-          {!isTabletAndBelow && ` ${t('avatar.edit')}`}
-        </Button>
+        <div className={styles.editButton}>
+          <JumpIn
+            variant="button"
+            buttonText={isTabletAndBelow ? undefined : t('avatar.edit')}
+            hideIcon={false}
+            modalProps={{
+              title: t('avatar.download_modal.title'),
+              description: t('avatar.download_modal.description'),
+              buttonLabel: t('avatar.download_modal.button_label')
+            }}
+          />
+        </div>
       )}
     </div>
   )

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -64,9 +64,9 @@ const Avatar = (props: Props) => {
             buttonText={isTabletAndBelow ? undefined : t('avatar.edit')}
             hideIcon={false}
             modalProps={{
-              title: t('avatar.download_modal.title'),
-              description: t('avatar.download_modal.description'),
-              buttonLabel: t('avatar.download_modal.button_label')
+              title: t('avatar.download_modal_title'),
+              description: t('avatar.download_modal_description'),
+              buttonLabel: t('avatar.download_modal_button_label')
             }}
           />
         </div>

--- a/src/components/ProfileInformation/ProfileInformation.tsx
+++ b/src/components/ProfileInformation/ProfileInformation.tsx
@@ -259,9 +259,9 @@ const ProfileInformation = (props: Props) => {
       </div>
       {showQRCode && <ShareQRCodeModal profileAddress={profileAddress} profile={profile} onClose={handleHideQRcode} />}
       <DownloadModal
-        title={t('avatar.download_modal.title')}
-        description={t('avatar.download_modal.description')}
-        buttonLabel={t('avatar.download_modal.button_label')}
+        title={t('avatar.download_modal_title')}
+        description={t('avatar.download_modal_description')}
+        buttonLabel={t('avatar.download_modal_button_label')}
         open={showDownloadModal}
         onClose={() => setShowDownloadModal(false)}
         onDownloadClick={handleDownloadClick}

--- a/src/components/ProfileInformation/ProfileInformation.tsx
+++ b/src/components/ProfileInformation/ProfileInformation.tsx
@@ -8,12 +8,13 @@ import { Dropdown } from 'decentraland-ui/dist/components/Dropdown/Dropdown'
 import { useTabletAndBelowMediaQuery } from 'decentraland-ui/dist/components/Media/Media'
 import { Popup } from 'decentraland-ui/dist/components/Popup/Popup'
 import { Profile } from 'decentraland-ui/dist/components/Profile/Profile'
+import { DownloadModal, launchDesktopApp } from 'decentraland-ui2'
 import Share from '../../assets/icons/Share.svg'
 import Wallet from '../../assets/icons/Wallet.svg'
 import { Events, ShareType } from '../../modules/analytics/types'
 import { config } from '../../modules/config/config'
 import { getAvatarName, hasAboutInformation } from '../../modules/profile/utils'
-import { getEditAvatarUrl, locations } from '../../modules/routing/locations'
+import { locations } from '../../modules/routing/locations'
 import { useTimer } from '../../utils/timer'
 import { hasHttpProtocol } from '../../utils/url'
 import { AvatarLink } from '../AvatarLink'
@@ -24,12 +25,12 @@ import MutualFriendsCounter from '../MutualFriendsCounter'
 import WorldsButton from '../WorldsButton'
 import {
   MAX_DESCRIPTION_LENGTH,
+  MAX_NUMBER_OF_LINKS,
   actionsForNonBlockedTestId,
   blockedButtonTestId,
   shareButtonTestId,
   twitterURL,
-  walletTestId,
-  MAX_NUMBER_OF_LINKS
+  walletTestId
 } from './constants'
 import ShareQRCodeModal from './ShareQrCodeModal'
 import { Props } from './ProfileInformation.types'
@@ -43,6 +44,7 @@ const ProfileInformation = (props: Props) => {
   const [hasCopiedLink, setHasCopiedLink] = useTimer(1200)
   const [hasCopiedWallet, setHasCopiedWallet] = useTimer(1200)
   const [showQRCode, setShowQRCode] = useState(false)
+  const [showDownloadModal, setShowDownloadModal] = useState(false)
   const isTabletAndBelow = useTabletAndBelowMediaQuery()
 
   const avatar = profile?.avatars[0]
@@ -76,6 +78,19 @@ const ProfileInformation = (props: Props) => {
 
     return () => clearTimeout(timeout)
   }, [profileAddress, loggedInAddress])
+
+  const handleEditAvatar = useCallback(async () => {
+    const hasLauncher = await launchDesktopApp()
+    if (!hasLauncher) {
+      setShowDownloadModal(true)
+    }
+  }, [])
+
+  const handleDownloadClick = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    e.preventDefault()
+    window.open('https://decentraland.org/download', '_blank')
+  }, [])
 
   const handleShowQrCode = () => setShowQRCode(true)
 
@@ -172,7 +187,7 @@ const ProfileInformation = (props: Props) => {
               direction="left"
             >
               <Dropdown.Menu>
-                <Dropdown.Item as="a" icon={'user'} text={t('profile_information.edit')} href={getEditAvatarUrl()} target="_blank" />
+                <Dropdown.Item icon={'user'} text={t('profile_information.edit')} onClick={handleEditAvatar} />
               </Dropdown.Menu>
             </Dropdown>
           )}
@@ -243,6 +258,14 @@ const ProfileInformation = (props: Props) => {
         )}
       </div>
       {showQRCode && <ShareQRCodeModal profileAddress={profileAddress} profile={profile} onClose={handleHideQRcode} />}
+      <DownloadModal
+        title={t('avatar.download_modal.title')}
+        description={t('avatar.download_modal.description')}
+        buttonLabel={t('avatar.download_modal.button_label')}
+        open={showDownloadModal}
+        onClose={() => setShowDownloadModal(false)}
+        onDownloadClick={handleDownloadClick}
+      />
     </div>
   )
 }

--- a/src/modules/routing/locations.ts
+++ b/src/modules/routing/locations.ts
@@ -23,11 +23,6 @@ export const getJumpToWorldUrl = (world: World) => {
     : `${EXPLORER_URL}/world/${world.domain}`
 }
 
-export const getEditAvatarUrl = () => {
-  const EXPLORER_URL = config.get('EXPLORER_URL')
-  return `${EXPLORER_URL}?OPEN_AVATAR_EDITOR${config.is(Env.DEVELOPMENT) ? '&NETWORK=sepolia' : ''}`
-}
-
 export const getMarketplaceNFTDetailUrl = (contractAddress: string, tokenId: string) => {
   const MARKETPLACE_URL = config.get('MARKETPLACE_URL')
   return `${MARKETPLACE_URL}/contracts/${contractAddress}/tokens/${tokenId}`

--- a/src/modules/translation/locales/en.json
+++ b/src/modules/translation/locales/en.json
@@ -4,7 +4,12 @@
   },
   "avatar": {
     "edit": "Edit Avatar",
-    "message": "Edit your avatar in Decentraland"
+    "message": "Edit your avatar in Decentraland",
+    "download_modal": {
+      "title": "Download Decentraland",
+      "description": "To edit your avatar, you need the Decentraland desktop client installed.",
+      "button_label": "Download"
+    }
   },
   "profile_information": {
     "default_name": "Unnamed",

--- a/src/modules/translation/locales/en.json
+++ b/src/modules/translation/locales/en.json
@@ -5,11 +5,9 @@
   "avatar": {
     "edit": "Edit Avatar",
     "message": "Edit your avatar in Decentraland",
-    "download_modal": {
-      "title": "Download Decentraland",
-      "description": "To edit your avatar, you need the Decentraland desktop client installed.",
-      "button_label": "Download"
-    }
+    "download_modal_title": "Download Decentraland",
+    "download_modal_description": "To edit your avatar, you need the Decentraland desktop client installed.",
+    "download_modal_button_label": "Download"
   },
   "profile_information": {
     "default_name": "Unnamed",

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -5,11 +5,9 @@
   "avatar": {
     "edit": "Editar Avatar",
     "message": "Edita tu Avatar en Decentraland",
-    "download_modal": {
-      "title": "Descargar Decentraland",
-      "description": "Para editar tu avatar, necesitás tener instalado el cliente de escritorio de Decentraland.",
-      "button_label": "Descargar"
-    }
+    "download_modal_title": "Descargar Decentraland",
+    "download_modal_description": "Para editar tu avatar, necesitás tener instalado el cliente de escritorio de Decentraland.",
+    "download_modal_button_label": "Descargar"
   },
   "profile_information": {
     "default_name": "Sin nombrar",

--- a/src/modules/translation/locales/es.json
+++ b/src/modules/translation/locales/es.json
@@ -4,7 +4,12 @@
   },
   "avatar": {
     "edit": "Editar Avatar",
-    "message": "Edita tu Avatar en Decentraland"
+    "message": "Edita tu Avatar en Decentraland",
+    "download_modal": {
+      "title": "Descargar Decentraland",
+      "description": "Para editar tu avatar, necesitás tener instalado el cliente de escritorio de Decentraland.",
+      "button_label": "Descargar"
+    }
   },
   "profile_information": {
     "default_name": "Sin nombrar",

--- a/src/modules/translation/locales/zh.json
+++ b/src/modules/translation/locales/zh.json
@@ -5,11 +5,9 @@
   "avatar": {
     "edit": "編輯頭像",
     "message": "在 Decentraland 中编辑您的头像",
-    "download_modal": {
-      "title": "下载 Decentraland",
-      "description": "要编辑您的头像，您需要安装 Decentraland 桌面客户端。",
-      "button_label": "下载"
-    }
+    "download_modal_title": "下载 Decentraland",
+    "download_modal_description": "要编辑您的头像，您需要安装 Decentraland 桌面客户端。",
+    "download_modal_button_label": "下载"
   },
   "profile_information": {
     "default_name": "未命名的",

--- a/src/modules/translation/locales/zh.json
+++ b/src/modules/translation/locales/zh.json
@@ -4,7 +4,12 @@
   },
   "avatar": {
     "edit": "編輯頭像",
-    "message": "在 Decentraland 中编辑您的头像"
+    "message": "在 Decentraland 中编辑您的头像",
+    "download_modal": {
+      "title": "下载 Decentraland",
+      "description": "要编辑您的头像，您需要安装 Decentraland 桌面客户端。",
+      "button_label": "下载"
+    }
   },
   "profile_information": {
     "default_name": "未命名的",


### PR DESCRIPTION
## Summary

- Replaced the "Edit Avatar" button/link that opened the web explorer (`play.decentraland.org?OPEN_AVATAR_EDITOR`) with the `JumpIn` component from `decentraland-ui2`.
- Clicking "Edit Avatar" now attempts to launch the native desktop client via `decentraland://` deep link. If the client is not installed, a download modal is shown instead.
- Applied the same behavior to the "Edit" option in the profile dropdown menu (using `launchDesktopApp` + `DownloadModal` directly).
- Removed the now-unused `getEditAvatarUrl()` function from `locations.ts`.
- Added download modal translation keys for `en`, `es`, and `zh`.

## Test plan

- [ ] View your own profile → "Edit Avatar" button should attempt to open the desktop client
- [ ] If desktop client is installed → game launches
- [ ] If desktop client is not installed → download modal appears with a download button
- [ ] Profile dropdown "Edit" option should have the same behavior
- [ ] Viewing another user's profile → no edit button/option shown
- [ ] Verify translations render correctly in EN/ES/ZH
